### PR TITLE
change the request for component 

### DIFF
--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -2,9 +2,9 @@ import LeftSide from "@/app/(docs)/layout-parts/left-side/left-side";
 import React from "react";
 import { Toaster } from "@/components/ui/toaster";
 
-import Requestcomponets from "@/components/requestcomponets";
+
 import type { Viewport } from "next";
-import RequestComponents from "@/components/requestcomponets";
+// import RequestComponents from "@/components/requestcomponets";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -26,7 +26,7 @@ export default function DocsLayout({
   <section className="flex flex-1 flex-col overflow-auto px-6" role="main" aria-label="Main content">
     <div className="flex-1">
       <div className="mb-4">
-        <RequestComponents />
+        {/* <RequestComponents /> */}
       </div>
       {children}
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
         variants={staggerItem}
       >
         <div className="flex flex-col items-center">
-          {/* <Requestcomponents /> */}
+        
           <h1 className="md:text-6xl text-2xl text-center md:mt-12 font-bold">
             Instant UI Components <br /> Just{" "}
             <Cover>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,8 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardTitle } from "@/components/ui/card";
 import CardCollection from "@/components/spectrumui/cards";
-import Requestcomponents from "@/components/shinebutton";
+// import Requestcomponents from "@/components/shinebutton";
+import RequestComponents from "@/components/requestcomponets";
 
 export default function Home() {
   // Motion configuration for staggered animations
@@ -36,12 +37,13 @@ export default function Home() {
       animate="visible"
     >
       <Spotlight className="-top-40 left-0 md:left-60 md:-top-20" fill="gray" />
+      <div className="pt-3"><RequestComponents/></div>
       <motion.div
         className="flex items-center justify-center mt-12"
         variants={staggerItem}
       >
         <div className="flex flex-col items-center">
-          <Requestcomponents />
+          {/* <Requestcomponents /> */}
           <h1 className="md:text-6xl text-2xl text-center md:mt-12 font-bold">
             Instant UI Components <br /> Just{" "}
             <Cover>

--- a/components/requestcomponets.tsx
+++ b/components/requestcomponets.tsx
@@ -205,3 +205,4 @@ export default function RequestComponents() {
     </AlertDialog>
   );
 }
+


### PR DESCRIPTION
Hey Arihant, I changed the introducing spectrum-UI button on the main page to request for a component Button and deleted this  request for the component Button from all the component's top bar
## ISSUE
When you will go to the component tab and select the testimonial component from the components after that, if you want to send a request for a component then you see the image overlaps the request form actually, if you see Aceternity UI and more websites like this you will see that after selecting component there is no option for send a request for component

# Before
<img width="1422" alt="Screenshot 2024-12-21 at 2 08 33 PM" src="https://github.com/user-attachments/assets/bffee6fb-6817-4fda-89e8-b31f8152306e" />
<img width="1425" alt="Screenshot 2024-12-21 at 2 08 49 PM" src="https://github.com/user-attachments/assets/72d4b4bb-07c3-435c-b8bc-d9be22edf140" />

# After
<img width="1429" alt="Screenshot 2024-12-21 at 2 07 56 PM" src="https://github.com/user-attachments/assets/210dcc95-d0df-47bf-9541-04c783e8869a" />
<img width="1407" alt="Screenshot 2024-12-21 at 2 08 17 PM" src="https://github.com/user-attachments/assets/4e769173-d98f-4ae9-93e5-70784c275bda" />

