### PR TITLE
fix: snippet mobile responsiveness

### DIFF
--- a/app/(docs)/docs/eventcalendar/page.tsx
+++ b/app/(docs)/docs/eventcalendar/page.tsx
@@ -16,7 +16,7 @@ const page = () => {
         </PreviewCodeCard>
 
         <PageSubTitle>Installation</PageSubTitle>
-        <div className="p-4 ">
+        <div className="p-0 md:p-4">
         <p className="mb-4">
           Create a new file called <code>Eventcalendar.tsx</code> in the
           {" components"} & install the following components

--- a/app/(docs)/docs/installation/page.tsx
+++ b/app/(docs)/docs/installation/page.tsx
@@ -45,7 +45,7 @@ export default function Component() {
               one:
             </p>
 
-            <div className="p-4 space-y-4">
+            <div className="p-0 md:p-4 space-y-4">
               <Snippet text="npx create-next-app@latest" width="740px" />
             </div>
           </div>
@@ -57,7 +57,7 @@ export default function Component() {
               <h2 className="text-lg font-semibold">Install Shadcn UI</h2>
             </div>
 
-            <div className="p-4 space-y-4">
+            <div className="p-0 md:p-4 space-y-4">
               <Snippet text="npx shadcn@latest init" width="740px" />
               <div>
                 <Card className="flex flex-col gap-7 p-6">

--- a/components/snippet.tsx
+++ b/components/snippet.tsx
@@ -4,12 +4,13 @@ import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import Copy from "./copy";
+
 interface SnippetProps {
   text: string;
   width?: string;
 }
 
-export function Snippet({ text, width = "300px" }: SnippetProps) {
+export function Snippet({ text, width }: SnippetProps) {
   const [copied, setCopied] = useState(false);
 
   const copyToClipboard = () => {
@@ -20,8 +21,10 @@ export function Snippet({ text, width = "300px" }: SnippetProps) {
   };
 
   return (
-    <Card className="flex items-center justify-between p-2" style={{ width }}>
-      <code className="text-sm font-mono">{text}</code>
+    <Card 
+      className={`flex items-center justify-between p-2 w-full max-w-[300px] sm:max-w-[400px] md:max-w-[500px] lg:max-w-[740px] ${width ? "max-w-none" : ""}`}
+    >
+      <code className="text-sm font-mono truncate flex-1 mr-2">{text}</code>
       <Copy content={text} />
     </Card>
   );


### PR DESCRIPTION
-Snippet Component isnt responsive in mobile,Fixed that

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/226f19d8-87ed-4f0f-b9b3-ae2d9e783f22" width="100%" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/eb0630d0-963f-446b-869a-6793574b452b" width="100%" controls></video>
    </td>
  </tr>
</table>







