### PR TITLE
fix: add spacing between nav links and search bar to ensure proper focus behavior

### DIFF
--- a/app/(docs)/docs/navbar/usage/sidenav.tsx
+++ b/app/(docs)/docs/navbar/usage/sidenav.tsx
@@ -1,16 +1,23 @@
-"use client"
-import React, { useState } from "react"
-import { Button } from "@/components/ui/button"
+"use client";
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@/components/ui/collapsible"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import { ChevronDown, ChevronRight, Home, Menu, Package, Settings, Users } from "lucide-react"
+} from "@/components/ui/collapsible";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  ChevronRight,
+  Home,
+  Menu,
+  Package,
+  Settings,
+  Users,
+} from "lucide-react";
+import { useState } from "react";
 
 export default function Sidenavbar() {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     //add h-screen to the div class name to make the sidebar full height
@@ -21,10 +28,16 @@ export default function Sidenavbar() {
         } flex flex-col border-r transition-all duration-300 ease-in-out`}
       >
         <div className="flex h-16 items-center justify-between border-b px-4">
-          <span className={`${isOpen ? "block" : "hidden"} text-lg font-semibold`}>
+          <span
+            className={`${isOpen ? "block" : "hidden"} text-lg font-semibold`}
+          >
             Menu
           </span>
-          <Button variant="ghost" size="icon" onClick={() => setIsOpen(!isOpen)}>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setIsOpen(!isOpen)}
+          >
             <Menu className="h-6 w-6" />
           </Button>
         </div>
@@ -34,30 +47,48 @@ export default function Sidenavbar() {
               <Home className="mr-2 h-4 w-4" />
               {isOpen && "Home"}
             </Button>
-            <Collapsible>
-              <CollapsibleTrigger asChild>
-                <Button variant="ghost" className="w-full justify-start">
-                  <Package className="mr-2 h-4 w-4" />
-                  {isOpen && (
-                    <>
-                      Products
-                      <ChevronRight className="ml-auto h-4 w-4" />
-                    </>
-                  )}
-                </Button>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="ml-4 space-y-1">
-                <Button variant="ghost" size="sm" className="w-full justify-start">
-                  Category 1
-                </Button>
-                <Button variant="ghost" size="sm" className="w-full justify-start">
-                  Category 2
-                </Button>
-                <Button variant="ghost" size="sm" className="w-full justify-start">
-                  Category 3
-                </Button>
-              </CollapsibleContent>
-            </Collapsible>
+            {isOpen ? (
+              <Collapsible>
+                <CollapsibleTrigger asChild>
+                  <Button variant="ghost" className="w-full justify-start">
+                    <Package className="mr-2 h-4 w-4" />
+                    {isOpen && (
+                      <>
+                        Products
+                        <ChevronRight className="ml-auto h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="ml-4 space-y-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start"
+                  >
+                    Category 1
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start"
+                  >
+                    Category 2
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start"
+                  >
+                    Category 3
+                  </Button>
+                </CollapsibleContent>
+              </Collapsible>
+            ) : (
+              <Button variant="ghost">
+                <Package className="mr-2 h-4 w-4" />
+              </Button>
+            )}
             <Button variant="ghost" className="w-full justify-start">
               <Users className="mr-2 h-4 w-4" />
               {isOpen && "Users"}
@@ -73,5 +104,5 @@ export default function Sidenavbar() {
         <h1 className="text-2xl font-bold">Main Content Area</h1>
       </main>
     </div>
-  )
+  );
 }

--- a/app/(docs)/docs/navbar/usage/tabnavbar.tsx
+++ b/app/(docs)/docs/navbar/usage/tabnavbar.tsx
@@ -18,7 +18,7 @@ import Link from "next/link"
 export default function Tabnavbar() {
   return (
     <nav className="border-b">
-      <div className="container mx-auto flex items-center justify-between px-4 py-2 sm:px-6 lg:px-8">
+      <div className="container mx-auto flex items-center justify-between space-x-4 px-4 py-2 sm:px-6 lg:px-8">
         <div className="flex items-center space-x-4">
           <Link href="#" className="text-2xl font-bold">
             Logo


### PR DESCRIPTION
The search bar was positioned directly beneath one of the navigation links. This caused unintended behavior where clicking the link also affected the focus state of the search input
![image](https://github.com/user-attachments/assets/616b74c4-1c94-4701-bfae-7063c626d160)

✅Added spacing between the the navigation links section and search bar section.

![image](https://github.com/user-attachments/assets/79ffbb2f-b32f-4e32-9590-5ceed13be150)
