### PR TITLE
docs(sidebar-navbar): fix the CLI link

### DIFF
--- a/app/(docs)/docs/navbar/page.tsx
+++ b/app/(docs)/docs/navbar/page.tsx
@@ -66,7 +66,7 @@ const DualRangeSliderPage = () => {
       <Usage
         title="Sidebar Navbar"
         path="app/(docs)/docs/navbar/usage/sidenav.tsx"
-        cli="https://ui.spectrumhq.in/r/sidenav-navbar.json"
+        cli="https://ui.spectrumhq.in/r/sidebar-navbar.json"
 
       >
         <Sidenavbar />


### PR DESCRIPTION
The docs contain an incorrect path for the sidebar-navbar, which results in an error. This update resolves the issue with that path, removing the error and allowing proper installation of the component.