### PR TITLE
image preview modal backdrop z index issue fixed

### DIFF
--- a/app/(docs)/docs/imagepreview/ImagePreview.tsx
+++ b/app/(docs)/docs/imagepreview/ImagePreview.tsx
@@ -36,8 +36,8 @@ export default function ImagePreview({
 
       <DialogPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
         <DialogPrimitive.Portal>
-          <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-          <DialogPrimitive.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] max-w-[90vw] max-h-[90vh] w-auto h-auto p-0 bg-transparent border-0">
+          <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[50]" />
+          <DialogPrimitive.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] max-w-[90vw] max-h-[90vh] w-auto h-auto p-0 bg-transparent border-0 z-[51]">
             <button
               onClick={() => setIsOpen(false)}
               className="absolute right-4 top-4 z-10 rounded-full bg-black/50 p-2 text-white hover:bg-black/75 focus:outline-none"


### PR DESCRIPTION
Image preview background z index issue fixed, i played around with z index values, 50 for backdrop and 51 for content works, 

![image](https://github.com/user-attachments/assets/03138666-2534-4b74-87b8-067ac3df1c16)
