### PR TITLE
refactor: improve blog post UI with readable text-based component dia…

### DIFF
--- a/app/blog/blog-list.tsx
+++ b/app/blog/blog-list.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import Link from 'next/link';
+import { Icons } from '@/components/icon';
+import { BlogPost } from '@/lib/blog';
+
+export function BlogList({ blogPosts }: { blogPosts: BlogPost[] }) {
+  const [activeCategory, setActiveCategory] = useState('All Posts');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const categories = useMemo(() => {
+    const cats = new Set<string>();
+    blogPosts.forEach((post) => {
+      if (post.category) {
+        cats.add(post.category);
+      }
+    });
+    return ['All Posts', ...Array.from(cats)];
+  }, [blogPosts]);
+
+  const filteredPosts = useMemo(() => {
+    return blogPosts.filter((post) => {
+      const matchesCategory = activeCategory === 'All Posts' || post.category === activeCategory;
+      const matchesSearch = post.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                            post.excerpt.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesCategory && matchesSearch;
+    });
+  }, [blogPosts, activeCategory, searchQuery]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground container-wrapper font-inter">
+      {/* Navigation */}
+      <div className="mt-12">
+        <div className="max-w-7xl mx-auto px-6 py-4">
+          <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+            <div className="flex flex-wrap items-center gap-2">
+              {categories.map((category) => (
+                <Button
+                  key={category}
+                  variant={activeCategory === category ? 'default' : 'ghost'}
+                  onClick={() => setActiveCategory(category)}
+                  className={`rounded-full text-sm ${
+                    activeCategory === category
+                      ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                  }`}
+                >
+                  {category}
+                </Button>
+              ))}
+            </div>
+
+            <div className="flex items-center space-x-4 w-full md:w-auto">
+              <div className="relative w-full">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                <Input
+                  placeholder="Search posts"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-10 bg-background border-border text-foreground placeholder-muted-foreground focus:border-ring rounded-xl w-full md:w-64"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Blog Grid with Dotted Borders */}
+      <div className="max-w-7xl mx-auto px-6 py-12">
+        {filteredPosts.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-muted-foreground text-lg">
+              No blog posts found matching your criteria.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-0 border border-dashed border-neutral-200 dark:border-neutral-800">
+            {filteredPosts.map((post) => (
+              <Link key={post.slug} href={`/blog/${post.slug}`}>
+                <div className="border-r border-b border-dashed border-neutral-200 dark:border-neutral-800 p-8 hover:bg-accent/20 transition-colors cursor-pointer group min-h-[400px] flex flex-col">
+                  <div className="flex items-start justify-between mb-6">
+                    <div className="h-6 w-6 bg-neutral-100 border-neutral-300 border dark:bg-white rounded-md flex items-center justify-center p-1">
+                      <Icons.logo className="h-5 w-5 text-black " />
+                    </div>
+                    <span className="text-sm text-muted-foreground font-mono">{post.date}</span>
+                  </div>
+
+                  <h3 className="text-xl font-semibold text-foreground mb-4 leading-tight group-hover:text-primary transition-colors">
+                    {post.title}
+                  </h3>
+
+                  <p className="text-sm text-muted-foreground mb-6 line-clamp-6">
+                    {post.excerpt || 'No excerpt available for this post.'}
+                  </p>
+                  <div className="flex items-center space-x-3 mt-auto">
+                    <Avatar className="h-7 w-7">
+                      <AvatarImage src={post.author.avatar || '/placeholder.svg'} />
+                      <AvatarFallback className="text-xs bg-muted">
+                        {post.author.name
+                          .split(' ')
+                          .map((n) => n[0])
+                          .join('')}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="text-sm text-muted-foreground">{post.author.name}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,20 +1,7 @@
-import { Search } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import Link from 'next/link';
 import { getAllBlogPosts } from '@/lib/blog';
-import { Icons } from '@/components/icon';
 import { Metadata } from 'next';
 import { generateBlogListingStructuredData, generateBlogBreadcrumbs } from '@/lib/seo-utils';
-
-const categories = [
-  'All Posts',
-  'Engineering',
- 
-  'Changelog',
-  'Press',
-];
+import { BlogList } from './blog-list';
 
 export const metadata: Metadata = {
   title: 'Blog | Spectrum UI - UI Components & Design System',
@@ -119,115 +106,7 @@ export default async function BlogPage() {
         }}
       />
       
-      <div className="min-h-screen bg-background text-foreground container-wrapper font-inter">
-      {/* Navigation */}
-      <div className="mt-12">
-        <div className="max-w-7xl mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-1">
-              {categories.map((category, index) => (
-                <Button
-                  key={category}
-                  variant={index === 0 ? 'default' : 'ghost'}
-                  className={`rounded-full text-sm ${
-                    index === 0
-                      ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                  }`}
-                >
-                  {category}
-                </Button>
-              ))}
-            </div>
-
-            <div className="flex items-center space-x-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                <Input
-                  placeholder="Search posts"
-                  className="pl-10 bg-background border-border text-foreground placeholder-muted-foreground focus:border-ring rounded-xl"
-                />
-              </div>
-             
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Blog Introduction */}
-  
-
-      {/* Blog Grid with Dotted Borders */}
-      <div className="max-w-7xl mx-auto px-6 py-12">
-        {blogPosts.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-muted-foreground text-lg">
-              No blog posts found. Add your content to get started!
-            </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-0 border border-dashed border-neutral-200 dark:border-neutral-800">
-            {blogPosts.map((post) => (
-              <Link key={post.slug} href={`/blog/${post.slug}`}>
-                <div className="border-r border-b border-dashed border-neutral-200 dark:border-neutral-800 p-8 hover:bg-accent/20 transition-colors cursor-pointer group min-h-[400px] flex flex-col">
-                  <div className="flex items-start justify-between mb-6">
-                  <div className="h-6 w-6 bg-neutral-100 border-neutral-300 border dark:bg-white rounded-md flex items-center justify-center p-1">
-          <Icons.logo className="h-5 w-5 text-black " />
-        </div>
-                    <span className="text-sm text-muted-foreground font-mono">{post.date}</span>
-                  </div>
-
-                  <h3 className="text-xl font-semibold text-foreground mb-4 leading-tight group-hover:text-primary transition-colors">
-                    {post.title}
-                  </h3>
-
-                  <p className="text-sm text-muted-foreground mb-6 line-clamp-6">
-                    {post.excerpt || 'No excerpt available for this post.'}
-                  </p>
-                  <div className="flex items-center space-x-3 mt-auto">
-                    <Avatar className="h-7 w-7">
-                      <AvatarImage src={post.author.avatar || '/placeholder.svg'} />
-                      <AvatarFallback className="text-xs bg-muted">
-                        {post.author.name
-                          .split(' ')
-                          .map((n) => n[0])
-                          .join('')}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="text-sm text-muted-foreground">{post.author.name}</span>
-                  </div>
-                </div>
-              </Link>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Call to Action Section */}
-      {/* <div className="max-w-7xl mx-auto px-6 py-16">
-        <div className="bg-gradient-to-r from-primary/10 to-secondary/10 rounded-2xl p-8 md:p-12 text-center">
-          <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
-            Ready to Build Amazing UIs?
-          </h2>
-          <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-            Explore our collection of React components and start building faster with Spectrum UI. 
-            Copy, paste, and customize components for your Next.js applications.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/">
-              <Button size="lg" className="w-full sm:w-auto">
-                Browse Components
-              </Button>
-            </Link>
-            <Link href="/colors">
-              <Button variant="outline" size="lg" className="w-full sm:w-auto">
-                View Color Palette
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </div> */}
-    </div>
+      <BlogList blogPosts={blogPosts} />
     </>
   );
 }

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -56,10 +56,13 @@ export function MainNav() {
           Blogs
         </Link>
         <Link href="/founder-story" className={cn(
-          'transition-colors hover:text-foreground/80',
+          'transition-colors hover:text-foreground/80 flex items-center',
           pathname === '/founder-story' ? 'text-foreground' : 'text-foreground/80',
         )}>
           Founder Story
+          <span className="text-[10px] ml-1.5 px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium">
+            New
+          </span>
         </Link>
       </nav>
     </div>

--- a/content/blog/nextjs-server-components-guide.tsx
+++ b/content/blog/nextjs-server-components-guide.tsx
@@ -38,35 +38,21 @@ const blogPost = {
         Think of it this way: your page starts as a server component. Any part that needs to respond to user clicks, track form state, or use browser features becomes a client component. Everything else stays on the server. This approach means the browser only downloads JavaScript for the interactive parts of your page, not the entire thing.
       </p>
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`How Server Components Work in Next.js:
-
-┌─────────────────────────────────────────────┐
-│              Server (Node.js)                │
-│                                             │
-│  ┌─────────────┐  ┌──────────────────────┐  │
-│  │ Page.tsx     │  │ DataDisplay.tsx       │  │
-│  │ (server)     │  │ (server)             │  │
-│  │              │  │                      │  │
-│  │ fetch data   │  │ render static HTML   │  │
-│  │ access DB    │  │ no JS sent to client │  │
-│  └──────┬──────┘  └──────────────────────┘  │
-│         │                                    │
-└─────────┼────────────────────────────────────┘
-          │ passes data as props
-┌─────────▼────────────────────────────────────┐
-│              Browser (Client)                │
-│                                              │
-│  ┌──────────────────────┐                    │
-│  │ InteractiveChart.tsx  │  "use client"     │
-│  │ (client component)   │                    │
-│  │                      │                    │
-│  │ onClick, useState    │                    │
-│  │ JS sent to browser   │                    │
-│  └──────────────────────┘                    │
-└──────────────────────────────────────────────┘`}
-        </pre>
+      <div className="bg-muted p-6 rounded-lg my-6 text-sm">
+        <h3 className="font-semibold text-foreground mb-4">How Server Components Work</h3>
+        <div className="space-y-4 text-muted-foreground">
+          <div className="border border-border bg-background p-4 rounded-md">
+            <h4 className="font-medium text-primary mb-2">1. Server (Node.js)</h4>
+            <p>Components like <code>Page.tsx</code> and <code>DataDisplay.tsx</code> fetch data, access databases, and render static HTML. No JavaScript is sent to the client.</p>
+          </div>
+          <div className="pl-4 border-l-2 border-primary/20 text-xs">
+            ↳ Passes data as props
+          </div>
+          <div className="border border-border bg-background p-4 rounded-md">
+            <h4 className="font-medium text-primary mb-2">2. Browser (Client)</h4>
+            <p>Components marked with <code>"use client"</code> like <code>InteractiveChart.tsx</code> handle interactivity (onClick, useState). Only their JavaScript is sent to the browser.</p>
+          </div>
+        </div>
       </div>
 
       <h3 className="text-xl font-semibold mt-6 mb-3">
@@ -348,25 +334,14 @@ export function LikeButton({ postId, initialLikes }: Props) {
 // If it fails, React automatically reverts the optimistic update`}
       />
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`Optimistic Update Flow:
-
-┌──────────┐     ┌──────────────┐     ┌──────────┐
-│  User    │────▶│  UI Updates  │────▶│  Server  │
-│  Clicks  │     │  INSTANTLY   │     │  Catches │
-│  Like    │     │  (optimistic)│     │  Up      │
-└──────────┘     └──────────────┘     └────┬─────┘
-                                           │
-                    ┌──────────────────────┘
-                    ▼
-          ┌─────────────────┐
-          │  Success?       │
-          │                 │
-          │  Yes: Keep it   │
-          │  No: Revert UI  │
-          └─────────────────┘`}
-        </pre>
+      <div className="bg-muted p-6 rounded-lg my-6 text-sm">
+        <h3 className="font-semibold text-foreground mb-4">Optimistic Update Flow</h3>
+        <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
+          <li><strong>User Clicks:</strong> User initiates an action (e.g., clicking a 'Like' button).</li>
+          <li><strong>UI Updates INSTANTLY:</strong> The UI is immediately updated optimistically before any server request completes.</li>
+          <li><strong>Server Catches Up:</strong> The server processes the mutation in the background.</li>
+          <li><strong>Resolution:</strong> If successful, the optimistic state is finalized. If an error occurs, the UI reverts to its previous state.</li>
+        </ol>
       </div>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">

--- a/content/blog/shadcn-customization-guide.tsx
+++ b/content/blog/shadcn-customization-guide.tsx
@@ -16,43 +16,35 @@ const blogPost = {
   content: (
     <div className="space-y-6">
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        What Makes Shadcn Different from Every Other Component Library
+        The Ownership Model
       </h2>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Shadcn UI isn&apos;t like other React component libraries. With most libraries, you install a package, import components, and hope the default styling works for your project. When it doesn&apos;t, you&apos;re stuck fighting with overrides and !important rules. Shadcn takes a completely different approach. Instead of installing packages, you copy the actual source code directly into your project. You own every single line.
+        Most component libraries lock you into an \`npm\` package. The moment you need a variant they didn't anticipate, you're overriding classes with \`!important\` or waiting on a PR. Shadcn UI flips this model: you copy the raw code into your repository. You own it.
       </p>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        This means you can change whatever you want. Want to tweak the button border radius? Go ahead. Want to add a new variant to your card component? Just edit the file. No waiting for the library maintainer to accept a pull request. No digging through node_modules. The code is right there in your project, and it&apos;s yours to shape however you need.
-      </p>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        But with great power comes the need for a good strategy. If you start making random changes without a plan, you&apos;ll end up with a mess that&apos;s hard to maintain and even harder to update. This guide will show you exactly how to customize shadcn components the right way, whether you&apos;re building with Next.js, React, or any frontend framework that uses Tailwind CSS. Let&apos;s walk through four proven methods that will make your design system truly yours.
-      </p>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        I&apos;ve been using shadcn in production apps for over a year now, and I&apos;ve tried every customization approach you can imagine. Some worked great, some created nightmares. What I&apos;m sharing here is the distilled version of all those experiments. The stuff that actually works when you&apos;re shipping real web applications with real deadlines and real teams.
+        This ownership is powerful, but dangerous without discipline. Haphazard edits to base components create maintenance nightmares and block future updates. The goal isn't to hack components until they work; it's to systematically adapt them into your own design system.
       </p>
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`Shadcn Customization Strategy:
-
-┌──────────────┐     ┌──────────────┐     ┌──────────────┐
-│  Install     │────▶│  Customize   │────▶│  Extend      │
-│  Component   │     │  Tokens      │     │  with Wrappers│
-│              │     │              │     │              │
-│ npx shadcn   │     │ CSS vars     │     │ New props    │
-│ add button   │     │ in globals   │     │ New features │
-└──────────────┘     └──────────────┘     └──────────────┘
-                                               │
-                          ┌────────────────────┘
-                          ▼
-                   ┌──────────────┐     ┌──────────────┐
-                   │  Compose     │────▶│  Your Brand  │
-                   │  Patterns    │     │  Design System│
-                   │              │     │              │
-                   │ Forms, Cards │     │ Consistent   │
-                   │ Dashboards   │     │ & Scalable   │
-                   └──────────────┘     └──────────────┘`}
-        </pre>
+      <div className="bg-muted p-6 rounded-lg my-6">
+        <h3 className="font-semibold text-foreground mb-4">The Customization Pipeline</h3>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
+          <div className="border border-border bg-background p-4 rounded-md">
+            <div className="font-medium text-primary mb-1">1. Install</div>
+            <p className="text-muted-foreground">Pull the raw component via CLI.</p>
+          </div>
+          <div className="border border-border bg-background p-4 rounded-md">
+            <div className="font-medium text-primary mb-1">2. Tokenize</div>
+            <p className="text-muted-foreground">Adjust global CSS variables.</p>
+          </div>
+          <div className="border border-border bg-background p-4 rounded-md">
+            <div className="font-medium text-primary mb-1">3. Wrap</div>
+            <p className="text-muted-foreground">Extend logic without touching base files.</p>
+          </div>
+          <div className="border border-border bg-background p-4 rounded-md">
+            <div className="font-medium text-primary mb-1">4. Compose</div>
+            <p className="text-muted-foreground">Build complex organisms.</p>
+          </div>
+        </div>
       </div>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
@@ -191,31 +183,13 @@ export function cn(...inputs: ClassValue[]) {
         Shadcn has an online theme generator that lets you pick colors visually and gives you the exact CSS variables to paste into your globals.css. It generates both light and dark mode values, saving you tons of time. Just pick your brand colors, copy the output, and paste it in. Your entire app updates in seconds. There are also community tools like shadcn-ui-theme-generator that give you even more control over the output.
       </p>
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`CSS Variable Theming Flow:
-
-┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
-│   globals.css    │     │  Tailwind Config  │     │   Components     │
-│                  │     │                  │     │                  │
-│  --primary:      │────▶│  primary:        │────▶│  bg-primary      │
-│    270 80% 60%   │     │    hsl(var(      │     │  text-primary    │
-│                  │     │    --primary))   │     │  border-primary  │
-│  --secondary:    │     │                  │     │                  │
-│    210 40% 96%   │     │  secondary:      │     │  bg-secondary    │
-│                  │     │    hsl(var(      │     │  text-secondary  │
-│  --destructive:  │     │    --secondary)) │     │                  │
-│    0 84% 60%     │     │                  │     │  bg-destructive  │
-└──────────────────┘     └──────────────────┘     └──────────────────┘
-        │
-        │  Change once here
-        ▼
-┌──────────────────┐
-│  Entire app      │
-│  updates at once │
-│  Light + Dark    │
-└──────────────────┘`}
-        </pre>
+      <div className="bg-muted p-6 rounded-lg my-6 text-sm">
+        <h3 className="font-semibold text-foreground mb-4">Theming Flow</h3>
+        <ul className="space-y-2 text-muted-foreground">
+          <li><strong>1. Definition:</strong> Define \`H S L\` values in \`globals.css\` (e.g., \`--primary: 270 80% 60%\`).</li>
+          <li><strong>2. Configuration:</strong> Map tokens in \`tailwind.config.js\` using \`hsl(var(--primary))\`.</li>
+          <li><strong>3. Consumption:</strong> Use standard utility classes like \`bg-primary\` or \`text-primary\` in your components.</li>
+        </ul>
       </div>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
@@ -417,27 +391,13 @@ export function ConfirmButton({
         </ul>
       </div>
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`Wrapper Pattern Architecture:
-
-┌───────────────────────────────────────┐
-│           Your App Code               │
-│  <LoadingButton />  <SearchInput />   │
-└──────────────┬────────────────────────┘
-               │ uses
-┌──────────────▼────────────────────────┐
-│         Wrapper Components            │
-│  LoadingButton  SearchInput  etc.     │
-│  (your custom props + logic)          │
-└──────────────┬────────────────────────┘
-               │ wraps
-┌──────────────▼────────────────────────┐
-│         Shadcn UI Primitives          │
-│  Button  Input  Dialog  Card  etc.    │
-│  (Radix UI + Tailwind CSS)            │
-└───────────────────────────────────────┘`}
-        </pre>
+      <div className="bg-muted p-6 rounded-lg my-6 text-sm">
+        <h3 className="font-semibold text-foreground mb-4">Wrapper Pattern Architecture</h3>
+        <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
+          <li><strong>Your App Code:</strong> Consumes the wrapped components (<code>&lt;LoadingButton /&gt;</code>, <code>&lt;SearchInput /&gt;</code>).</li>
+          <li><strong>Wrapper Components:</strong> Holds your custom props and business logic (\`loadingText\`, debouncing).</li>
+          <li><strong>Shadcn UI Primitives:</strong> The untouched base layer handling Radix UI accessibility and raw styling.</li>
+        </ol>
       </div>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">

--- a/content/blog/spectrum-ui-development-speed.tsx
+++ b/content/blog/spectrum-ui-development-speed.tsx
@@ -3,358 +3,110 @@ import CodeBlock from '@/components/blog-code';
 const blogPost = {
   title: 'How Spectrum UI Accelerates Development Speed and Design Consistency',
   excerpt:
-    "Ever feel like you spend too much time building the same buttons and forms over and over? Spectrum UI helps you build faster without sacrificing quality. Here is how it works.",
+    "We spend too much time rebuilding the same primitives. Spectrum UI solves this by providing composable, accessible components that you own, cutting development time without sacrificing quality.",
   author: {
     name: 'Arihant Jain',
     role: 'Engineering',
     avatar: '/arihant.jpeg',
   },
   date: 'Oct 25, 2025',
-  readTime: '15 min read',
+  readTime: '8 min read',
   icon: '⚡',
   category: 'Design Engineering',
   content: (
     <div className="space-y-6">
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Why Development Speed Actually Matters
+        The Reality of Frontend Development
       </h2>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Let&apos;s be honest. Nobody wants to spend hours building a button that looks exactly like the one they built last week. Or hand-coding a modal from scratch for the fifth time this month. Or debating with teammates about whether the card padding should be 16px or 20px. These things eat up your time and energy, and they don&apos;t move your product forward one bit.
+        Rebuilding the same button, modal, or dropdown menu for the tenth time is a massive drain on engineering resources. Teams waste countless hours debating padding, hover states, and focus outlines instead of shipping actual product features. 
       </p>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        But here&apos;s the thing: you can&apos;t just ship fast and ignore quality. Users notice when your buttons look different on every page. They notice when spacing is inconsistent. They notice when the dark mode toggle breaks half the UI. You need to ship fast AND keep everything looking consistent and polished. Most teams end up choosing one or the other. Spectrum UI lets you have both.
-      </p>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        In this guide, we&apos;ll walk through exactly how Spectrum UI accelerates your frontend development speed while maintaining design consistency across your entire React and Next.js application. Whether you&apos;re a solo developer or part of a large team, these principles and patterns will make your web dev workflow significantly more productive.
+        The tradeoff historically has been: move fast and ship an inconsistent, inaccessible mess, or move slow and build perfect custom components from scratch. Spectrum UI eliminates this tradeoff. You get the speed of a UI library with the control and consistency of a bespoke design system.
       </p>
 
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`Development Without a Component Library:
-
-┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
-│  Design  │────▶│  Build   │────▶│  Debug   │────▶│  Repeat  │
-│  from    │     │  from    │     │  styling │     │  for     │
-│  scratch │     │  scratch │     │  issues  │     │  every   │
-│  (slow)  │     │  (slow)  │     │  (slow)  │     │  page    │
-└──────────┘     └──────────┘     └──────────┘     └──────────┘
-
-Development With Spectrum UI:
-
-┌──────────┐     ┌──────────┐     ┌──────────┐
-│  Pick    │────▶│  Compose │────▶│  Ship    │
-│  Components    │  & Customize    │  Fast    │
-│  (minutes)│    │  (minutes)│    │  (done!) │
-└──────────┘     └──────────┘     └──────────┘`}
-        </pre>
-      </div>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        The Real Cost of Building Components from Scratch
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Before we talk about the solution, let&apos;s be clear about the problem. Building UI components from scratch is expensive. Not just in time, but in quality. Think about what goes into a single button component. You need hover states, focus states, active states, disabled states. You need keyboard navigation. You need ARIA attributes for screen readers. You need multiple sizes and variants. You need it to work in both light and dark mode. You need it to look good on mobile and desktop. That&apos;s not a few minutes of work. That&apos;s hours of careful implementation and testing.
-      </p>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Now multiply that by every component in your app. Buttons, inputs, cards, modals, dropdowns, tabs, tooltips, data tables, forms. Each one needs the same level of care. And every time a new developer joins your team, they need to learn your custom component conventions from scratch. It&apos;s a huge investment that doesn&apos;t directly contribute to what makes your product unique.
-      </p>
-
-      <h3 className="text-xl font-semibold mt-6 mb-3">
-        Time Savings Are Real and Measurable
-      </h3>
-      <div className="border border-dashed border-neutral-200 dark:border-neutral-800 p-6 rounded-lg my-6">
-        <ul className="space-y-2 list-disc list-inside">
-          <li><strong>Component development:</strong> Build UI components 70% faster by starting with pre-built, tested primitives</li>
-          <li><strong>Design consistency:</strong> Zero time spent debating button styles or card padding. It&apos;s already defined.</li>
-          <li><strong>Feature velocity:</strong> Ship complete features 3x faster because you&apos;re not rebuilding infrastructure</li>
-          <li><strong>Accessibility:</strong> Built-in a11y means you&apos;re not spending extra time adding screen reader support</li>
-          <li><strong>Onboarding:</strong> New developers are productive in hours, not weeks, because shadcn patterns are well documented</li>
-        </ul>
-      </div>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        What Makes Spectrum UI Different
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Spectrum UI is built on top of shadcn and Radix UI. This means you get the best of three worlds: beautifully designed components that you fully own, rock-solid accessibility from Radix UI, and the flexibility of Tailwind CSS for styling. Unlike traditional component libraries where you install a package and hope the API fits your needs, Spectrum UI components live directly in your project. You can read, modify, and extend them however you want.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        The Technical Foundation
-      </h4>
       <div className="bg-muted p-6 rounded-lg my-6">
-        <ul className="space-y-2 list-disc list-inside">
-          <li><strong>You own the code:</strong> Every component is copied into your project. No node_modules black box.</li>
-          <li><strong>Radix UI primitives:</strong> Keyboard navigation, focus management, and screen reader support are built in from day one.</li>
-          <li><strong>Tailwind CSS styling:</strong> Consistent, utility-first styling that&apos;s easy to customize and maintain.</li>
-          <li><strong>TypeScript first:</strong> Full type safety catches bugs before they reach production.</li>
-          <li><strong>Dark mode ready:</strong> CSS variable-based theming means light and dark mode just work out of the box.</li>
-        </ul>
+        <h3 className="font-medium text-foreground mb-4">The Workflow Shift</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="border border-dashed border-destructive/50 bg-destructive/5 p-4 rounded-md">
+            <h4 className="font-semibold text-sm mb-2 text-destructive">The Old Way</h4>
+            <ul className="text-sm space-y-2 text-muted-foreground">
+              <li>1. Design from scratch</li>
+              <li>2. Build custom component</li>
+              <li>3. Fight CSS specificity</li>
+              <li>4. Discover accessibility bugs</li>
+              <li>5. Repeat for every new view</li>
+            </ul>
+          </div>
+          <div className="border border-dashed border-primary/50 bg-primary/5 p-4 rounded-md">
+            <h4 className="font-semibold text-sm mb-2 text-primary">The Spectrum Way</h4>
+            <ul className="text-sm space-y-2 text-muted-foreground">
+              <li>1. Copy the primitive</li>
+              <li>2. Paste into your codebase</li>
+              <li>3. Compose and customize</li>
+              <li>4. Ship feature</li>
+            </ul>
+          </div>
+        </div>
       </div>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        The Copy-Paste-Customize Workflow
+        Why Traditional Component Libraries Fail
       </h2>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        The Spectrum UI workflow is refreshingly simple. Browse the component library, find what you need, copy it into your project, and customize it to match your brand. No dependency management headaches. No version conflicts. No waiting for library maintainers to fix a bug or add a feature. You own everything and can change anything.
+        Traditional npm-installed component libraries trap you in their ecosystem. When you need a variant they don't support, you end up writing hacky CSS overrides or filing feature requests that take months to resolve. Spectrum UI adopts the <i>copy-paste</i> philosophy. The code lives in your repository. You own it.
       </p>
 
-      <h5 className="text-base font-semibold mt-4 mb-2 text-neutral-800 dark:text-neutral-200">
-        Why This Is Better Than Traditional Libraries
-      </h5>
       <CodeBlock
         filename="CustomButton.tsx"
         language="tsx"
-        code={`// Traditional library approach:
-// You're stuck with their API and their design decisions
-import { Button } from 'some-library'
-// Want to change something? Override with !important or file an issue
-
-// Spectrum UI / shadcn approach:
-// You own the code and can change ANYTHING
+        code={`// The Spectrum UI approach: You own the code.
 import { Button } from '@/components/ui/button'
 
-// Need a custom variant? Just add it:
 export function GradientButton({ children, ...props }) {
   return (
     <Button
-      className="bg-gradient-to-r from-purple-500 to-pink-500
-                 text-white hover:opacity-90 transition-opacity"
+      className="bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:opacity-90"
       {...props}
     >
       {children}
     </Button>
   )
-}
-
-// Need to modify the base component? Open the file and edit it.
-// No fighting with specificity or library APIs.`}
-      />
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Design Consistency Without the Effort
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Ever worked on a team where every developer builds buttons differently? One person uses 12px border radius, another uses 8px. One person prefers blue, another uses indigo. The spacing is different on every page. It&apos;s a nightmare for users, and it makes your app look unprofessional. Spectrum UI fixes this problem at the root by giving every developer on your team the same building blocks.
-      </p>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        When everyone uses the same Button component, the same Card component, the same spacing tokens, consistency happens automatically. You don&apos;t need design reviews to catch inconsistencies because there are no inconsistencies to catch. The design system enforces consistency for you. This isn&apos;t just about looking pretty. When your app feels consistent, users know what to expect. They don&apos;t have to relearn your interface on every page.
-      </p>
-
-      <h3 className="text-xl font-semibold mt-6 mb-3">
-        How Design Tokens Keep Everything Aligned
-      </h3>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        At the heart of Spectrum UI&apos;s consistency is the design token system. Colors, spacing, typography, border radius, and shadows are all defined as CSS variables. Change one variable and every component that uses it updates instantly. Want to rebrand from blue to purple? Change one line. Want to adjust the border radius across your entire app? One variable. This is the power of a well-structured scalable design system.
-      </p>
-
-      <CodeBlock
-        filename="theme-customization.css"
-        language="css"
-        code={`/* Change your ENTIRE brand in one place */
-@layer base {
-  :root {
-    --primary: 221.2 83.2% 53.3%;     /* Your brand color */
-    --radius: 0.5rem;                   /* Global border radius */
-    --background: 0 0% 100%;           /* Background color */
-    --foreground: 222.2 84% 4.9%;      /* Text color */
-  }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-  }
-}
-
-/* Every Button, Card, Input, Dialog automatically uses these values
-   Change --primary and every accent color in your app updates */`}
-      />
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Real Example: Building a Dashboard in Minutes
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Let&apos;s see the speed advantage in action. Say you need to build a dashboard with stat cards, a data table, and a settings form. Without a component library, this is easily a full day of work. With Spectrum UI, you&apos;re looking at 30 minutes to an hour, and the result looks more professional because every component follows the same design system.
-      </p>
-
-      <CodeBlock
-        filename="Dashboard.tsx"
-        language="tsx"
-        code={`import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-
-export function Dashboard() {
-  return (
-    <div className="space-y-8">
-      {/* Stat cards - responsive grid */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm text-muted-foreground">
-              Revenue
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-bold">$45,231.89</p>
-            <p className="text-xs text-muted-foreground">
-              +20.1% from last month
-            </p>
-          </CardContent>
-        </Card>
-        {/* More stat cards... */}
-      </div>
-
-      {/* Quick settings form */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Quick Settings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">Display Name</Label>
-            <Input id="name" defaultValue="Arihant Jain" />
-          </div>
-          <Button>Save Changes</Button>
-        </CardContent>
-      </Card>
-    </div>
-  )
 }`}
       />
 
+      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
+        Enforcing Consistency Through Tokens
+      </h2>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        That&apos;s it. You just built a professional-looking dashboard that works on mobile, supports dark mode, has proper accessibility, and uses consistent spacing throughout. No hours of CSS fighting. No component building from scratch. No design debates. Just productive frontend development.
+        Consistency isn't achieved through design reviews; it's achieved through constraints. Spectrum UI uses CSS variables to define a strict set of design tokens. When every developer pulls from the same token scale, the app naturally converges on a cohesive look and feel.
+      </p>
+
+      <CodeBlock
+        filename="theme.css"
+        language="css"
+        code={`@layer base {
+  :root {
+    --primary: 221.2 83.2% 53.3%;
+    --radius: 0.5rem;
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+  }
+}`}
+      />
+
+      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
+        Accessibility Is Non-Negotiable
+      </h2>
+      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
+        Building an accessible dropdown menu or modal from scratch takes days. Spectrum UI primitives are built on top of Radix UI, meaning keyboard navigation, focus trapping, and screen reader announcements are handled out of the box. You get enterprise-grade accessibility without the overhead.
       </p>
 
       <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Scaling Across Teams
+        Summary
       </h2>
       <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        The benefits of Spectrum UI multiply as your team grows. When you have two developers, inconsistency is manageable. When you have ten, it becomes a serious problem. Every new developer brings their own habits, their own spacing preferences, their own component patterns. Without a shared design system, your UI slowly turns into a patchwork quilt of different styles.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        What Changes for Larger Teams
-      </h4>
-      <div className="bg-muted p-6 rounded-lg my-6">
-        <ul className="space-y-2 list-disc list-inside">
-          <li><strong>Faster onboarding:</strong> New developers learn the component API once and can contribute immediately across the entire app.</li>
-          <li><strong>Reduced code reviews:</strong> When everyone uses the same components, there&apos;s less to review and fewer style-related comments.</li>
-          <li><strong>Shared vocabulary:</strong> The team can communicate using component names. &quot;Use a Card with a destructive Button&quot; means the same thing to everyone.</li>
-          <li><strong>Less duplication:</strong> Without shared components, different teams build the same UI patterns independently. With Spectrum UI, they use the same building blocks.</li>
-          <li><strong>Consistent user experience:</strong> Every feature team ships UI that looks and feels like it belongs in the same app.</li>
-        </ul>
-      </div>
-
-      <div className="bg-muted p-6 rounded-lg my-6 font-mono text-sm overflow-x-auto">
-        <pre className="text-center">
-{`Team Scaling with Spectrum UI:
-
-Solo Dev          Small Team        Large Team
-┌──────────┐     ┌──────────┐     ┌──────────┐
-│ 1 dev    │     │ 3-5 devs │     │ 10+ devs │
-│          │     │          │     │          │
-│ Fast     │     │ Fast +   │     │ Fast +   │
-│ shipping │     │ Consistent│    │ Consistent│
-│          │     │ across   │     │ across   │
-│          │     │ features │     │ ALL teams│
-└──────────┘     └──────────┘     └──────────┘
-
-Speed gain:  2x          3x             5x+
-(vs building from scratch every time)`}
-        </pre>
-      </div>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Accessibility Out of the Box
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        One of the most underappreciated benefits of using Spectrum UI is that accessibility comes free. Radix UI, which powers the interactive components, handles keyboard navigation, focus management, screen reader announcements, and ARIA attributes automatically. You don&apos;t have to think about it, and you definitely don&apos;t have to build it yourself. For context, building accessible dropdown menus or dialog components from scratch takes days of careful work and testing. With Spectrum UI, it just works.
-      </p>
-
-      <h5 className="text-base font-semibold mt-4 mb-2 text-neutral-800 dark:text-neutral-200">
-        What You Get for Free
-      </h5>
-      <div className="border border-dashed border-neutral-200 dark:border-neutral-800 p-6 rounded-lg my-6">
-        <ul className="space-y-2 list-disc list-inside">
-          <li>Full keyboard navigation on all interactive components</li>
-          <li>Proper focus management for dialogs, dropdowns, and popovers</li>
-          <li>Screen reader announcements for state changes</li>
-          <li>Correct ARIA roles and attributes on every element</li>
-          <li>Focus trapping in modals so keyboard users don&apos;t get lost</li>
-          <li>Escape key handling to close overlays</li>
-        </ul>
-      </div>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Works Perfectly with Next.js Server Components
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Spectrum UI components are designed to work seamlessly with the Next.js App Router and server components. Static display components like Card, Badge, and Skeleton work as server components with zero client-side JavaScript. Interactive components like Dialog, Dropdown, and Form inputs use &quot;use client&quot; only where needed, keeping your JavaScript bundle small and your pages fast. This combination of Spectrum UI + Next.js server components gives you the best possible performance for your frontend.
-      </p>
-
-      <h6 className="text-sm font-semibold mt-3 mb-1 text-neutral-800 dark:text-neutral-200 uppercase tracking-wide">
-        Server Component Compatible Components
-      </h6>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Card, Badge, Skeleton, Avatar, Separator, and many other display-only components work without &quot;use client&quot; at all. This means they add zero JavaScript to your bundle. Combined with Next.js server-side data fetching, you can build entire pages that load instantly with no client-side JS overhead.
-      </p>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Getting Started: Your First Hour with Spectrum UI
-      </h2>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        If you&apos;re sold on the idea, here&apos;s how to get productive with Spectrum UI in your first hour. The goal is to go from zero to a working page with multiple components, consistent styling, and both light and dark mode support.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        Step 1: Set Up Your Theme (5 minutes)
-      </h4>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Configure your CSS variables in globals.css to match your brand colors. This one-time setup ensures every component you add will use your brand&apos;s visual identity automatically.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        Step 2: Add Your First Components (10 minutes)
-      </h4>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Start with the essentials: Button, Card, Input, and Label. These four components cover the majority of common UI patterns. Browse the Spectrum UI documentation, copy the components you need, and drop them into your project.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        Step 3: Build Your First Page (15 minutes)
-      </h4>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Compose those components into a real page. A settings page, a login form, a dashboard card grid. You&apos;ll be amazed at how quickly things come together when you&apos;re not building every element from scratch.
-      </p>
-
-      <h4 className="text-lg font-semibold mt-5 mb-2 text-neutral-800 dark:text-neutral-200">
-        Step 4: Customize to Your Brand (15 minutes)
-      </h4>
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        Fine-tune your theme tokens, add any custom button variants you need, and create wrapper components for patterns you&apos;ll reuse across your app. At this point, you have a working design system tailored to your brand.
-      </p>
-
-      <h2 className="text-xl font-medium mt-8 mb-4 text-neutral-800 dark:text-neutral-200">
-        Bottom Line
-      </h2>
-      <div className="border border-dashed border-neutral-200 dark:border-neutral-800 p-6 rounded-lg my-6">
-        <ul className="space-y-2 list-disc list-inside">
-          <li>Build UI components 70% faster by starting with pre-built, tested primitives from Spectrum UI</li>
-          <li>Maintain perfect design consistency without extra effort because everyone uses the same components</li>
-          <li>Get accessibility for free through Radix UI primitives built into every interactive component</li>
-          <li>Own your code completely with no vendor lock-in, unlike traditional npm component libraries</li>
-          <li>Scale seamlessly from solo developer to large teams with shared components and design tokens</li>
-          <li>Integrate perfectly with Next.js server components for the best possible performance</li>
-          <li>Customize everything through Tailwind CSS utility classes and CSS variable tokens</li>
-          <li>Works for every type of project: dashboards, marketing sites, SaaS apps, and more</li>
-        </ul>
-      </div>
-
-      <p className="text-base font-normal text-neutral-800 dark:text-neutral-200">
-        The best code is the code you don&apos;t have to write. Spectrum UI handles the tedious, repetitive parts of frontend development so you can focus on what makes your app special. The components are there. The design tokens are there. The accessibility is there. The dark mode support is there. All you need to do is compose them into something great. Stop rebuilding the same buttons and forms from scratch, and start shipping the features that matter to your users.
+        Stop treating UI components like special snowflakes. Leverage Spectrum UI to handle the repetitive boilerplate, enforce strict design constraints, and ensure baseline accessibility. This lets you focus your engineering cycles on building actual product logic rather than wrestling with flexbox alignment for the hundredth time.
       </p>
     </div>
   ),


### PR DESCRIPTION
…grams and implement a reusable blog list component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `BlogList` with category filters and search, and replaces ASCII art diagrams in blog posts with clean, responsive text-based sections for better readability and accessibility.

- **New Features**
  - Introduced `BlogList` (`app/blog/blog-list.tsx`) with dynamic category chips, search, and a responsive grid.
  - `/blog` now renders `BlogList` for a simpler, reusable listing experience.
  - Added a small “New” badge to the “Founder Story” link in the main nav.

- **Refactors**
  - Rewrote diagram sections in posts to structured content (headings, lists, cards) replacing monospace ASCII blocks for better UX and semantics:
    - `nextjs-server-components-guide.tsx`
    - `shadcn-customization-guide.tsx`
    - `spectrum-ui-development-speed.tsx` (also tightened copy, updated excerpt/readTime)
  - Trimmed duplicated UI from `app/blog/page.tsx` by delegating layout and filters to the client `BlogList` component.

<sup>Written for commit c2a1f0cc0518ff5fcfd9489f8c046b645b5185fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arihantcodes/spectrum-ui/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

