### PR TITLE
fix(catalog): ship 44 components (not 61) + restore sidebar New badges

### DIFF
--- a/app/(docs)/layout-parts/documentation.constant.ts
+++ b/app/(docs)/layout-parts/documentation.constant.ts
@@ -74,6 +74,7 @@ export const DOCS: Documentation[] = [
       label: component.name,
       value: component.slug,
       url: componentDocsPath(component.slug),
+      ...(component.new ? { new: true } : {}),
     })),
   },
 ];

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -32,6 +32,25 @@ const nonIndexableRoutes = new Set([
   "/sign-in",
   "/success",
   "/unsubscribe",
+  // Delisted components: pages still resolve but are not part of the shipped
+  // 44-component catalog, so keep them out of the sitemap.
+  "/docs/animatedtestimonials",
+  "/docs/animatedtext",
+  "/docs/bento-grid",
+  "/docs/command-palette",
+  "/docs/discloseimage",
+  "/docs/dock",
+  "/docs/eventcalendar",
+  "/docs/footer",
+  "/docs/github-card",
+  "/docs/heading-with-anchor",
+  "/docs/input",
+  "/docs/navbar",
+  "/docs/product-card",
+  "/docs/responsive-modal",
+  "/docs/skeleton",
+  "/docs/statuscode",
+  "/docs/testimonials",
 ]);
 
 const routeConfig: Record<string, RouteConfig> = {

--- a/content/component-catalog.json
+++ b/content/component-catalog.json
@@ -33,19 +33,8 @@
     "slug": "animateddrawer",
     "name": "Animated Drawer",
     "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars.",
-    "category": "Overlay"
-  },
-  {
-    "slug": "animatedtestimonials",
-    "name": "Animated Testimonials",
-    "description": "An animated testimonials section for showcasing customer reviews and social proof.",
-    "category": "Review"
-  },
-  {
-    "slug": "animatedtext",
-    "name": "Text Animations",
-    "description": "A collection of text effects including holographic, ink morph, and orbital reveals.",
-    "category": "Text"
+    "category": "Overlay",
+    "new": true
   },
   {
     "slug": "autosize-textarea",
@@ -57,19 +46,14 @@
     "slug": "avatar-stack",
     "name": "Avatar Stack",
     "description": "An overlapping avatar row that fans apart on hover with springy name tooltips.",
-    "category": "Profile"
+    "category": "Profile",
+    "new": true
   },
   {
     "slug": "badge",
     "name": "3D Event Badge",
     "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber.",
     "category": "Media"
-  },
-  {
-    "slug": "bento-grid",
-    "name": "Bento Grid",
-    "description": "A bento grid layout with physics-based hover effects and scroll animations.",
-    "category": "Layout"
   },
   {
     "slug": "button",
@@ -84,28 +68,10 @@
     "category": "Card"
   },
   {
-    "slug": "command-palette",
-    "name": "Command Palette",
-    "description": "A keyboard-driven command menu for navigation, actions, and theme switching.",
-    "category": "Navigation"
-  },
-  {
     "slug": "datetime-picker",
     "name": "Datetime Picker",
     "description": "A date and time picker built on shadcn/ui with no extra dependencies.",
     "category": "Form"
-  },
-  {
-    "slug": "discloseimage",
-    "name": "Disclose Image",
-    "description": "An image that reveals its content behind animated sliding door panels.",
-    "category": "Media"
-  },
-  {
-    "slug": "dock",
-    "name": "Dock Menu",
-    "description": "A macOS-style dock menu that magnifies icons on hover with tooltips.",
-    "category": "Navigation"
   },
   {
     "slug": "dual-range-slider",
@@ -114,16 +80,11 @@
     "category": "Form"
   },
   {
-    "slug": "eventcalendar",
-    "name": "Event Calendar",
-    "description": "An interactive calendar for displaying events, appointments, and daily schedules.",
-    "category": "Calendar"
-  },
-  {
     "slug": "face-rating",
     "name": "Face Rating",
     "description": "A five-level rating input where an SVG face morphs between moods.",
-    "category": "Rating"
+    "category": "Rating",
+    "new": true
   },
   {
     "slug": "feedback",
@@ -141,31 +102,15 @@
     "slug": "follow-button",
     "name": "Follow Button",
     "description": "A follow button that morphs its width, fill, and label between states.",
-    "category": "Action"
-  },
-  {
-    "slug": "footer",
-    "name": "Footer",
-    "description": "A collection of footers with wave, stacked, and particle animation styles.",
-    "category": "Layout"
-  },
-  {
-    "slug": "github-card",
-    "name": "GitHub Profile Card",
-    "description": "A GitHub profile card generator with stats, a contribution graph, and social links.",
-    "category": "Profile"
-  },
-  {
-    "slug": "heading-with-anchor",
-    "name": "Heading With Anchor",
-    "description": "A heading component that adds clickable anchor links for section sharing.",
-    "category": "Text"
+    "category": "Action",
+    "new": true
   },
   {
     "slug": "hold-to-confirm",
     "name": "Hold to Confirm",
     "description": "A press-and-hold button that fills a progress ring before confirming destructive actions.",
-    "category": "Action"
+    "category": "Action",
+    "new": true
   },
   {
     "slug": "imagepreview",
@@ -178,12 +123,6 @@
     "name": "Infinite Scroll",
     "description": "An infinite scroll container that loads more content using the IntersectionObserver API.",
     "category": "Data"
-  },
-  {
-    "slug": "input",
-    "name": "Input",
-    "description": "A form input field or a component that looks like an input field.",
-    "category": "Form"
   },
   {
     "slug": "input-model",
@@ -207,7 +146,8 @@
     "slug": "like-button",
     "name": "Like Button",
     "description": "A heart button that pops with a particle burst and rolling count.",
-    "category": "Action"
+    "category": "Action",
+    "new": true
   },
   {
     "slug": "loading-button",
@@ -240,28 +180,18 @@
     "category": "Form"
   },
   {
-    "slug": "navbar",
-    "name": "Navbar",
-    "description": "A collection of responsive navbars with circular, tab, floating, and sidebar patterns.",
-    "category": "Navigation"
-  },
-  {
     "slug": "notification-bell",
     "name": "Notification Bell",
     "description": "A bell button that swings on new notifications with a rolling unread badge.",
-    "category": "Feedback"
+    "category": "Feedback",
+    "new": true
   },
   {
     "slug": "password-strength",
     "name": "Password Strength",
     "description": "A password input with an animated strength meter and requirements checklist.",
-    "category": "Form"
-  },
-  {
-    "slug": "product-card",
-    "name": "Product Card",
-    "description": "A product card that displays an image, title, price, and rating.",
-    "category": "Card"
+    "category": "Form",
+    "new": true
   },
   {
     "slug": "profile",
@@ -285,31 +215,21 @@
     "slug": "reaction-bar",
     "name": "Reaction Bar",
     "description": "A Slack-style emoji reaction bar with animated chips and rolling counts.",
-    "category": "Feedback"
-  },
-  {
-    "slug": "responsive-modal",
-    "name": "Responsive Modal",
-    "description": "A dialog that centers on desktop and slides up as a sheet on mobile.",
-    "category": "Overlay"
+    "category": "Feedback",
+    "new": true
   },
   {
     "slug": "scratch-card",
     "name": "Scratch Card",
     "description": "A scratch-to-reveal card that wipes away a canvas foil overlay on drag.",
-    "category": "Media"
+    "category": "Media",
+    "new": true
   },
   {
     "slug": "share-button",
     "name": "Share Button",
     "description": "A share button that fans out into copy-link and custom share actions.",
     "category": "Action"
-  },
-  {
-    "slug": "skeleton",
-    "name": "Skeleton",
-    "description": "A loading placeholder that shimmer-animates while content is fetching.",
-    "category": "Feedback"
   },
   {
     "slug": "spinner",
@@ -321,7 +241,8 @@
     "slug": "star-rating",
     "name": "Star Rating",
     "description": "An animated star rating input with hover preview and sparkle burst effects.",
-    "category": "Rating"
+    "category": "Rating",
+    "new": true
   },
   {
     "slug": "status-badge",
@@ -330,39 +251,31 @@
     "category": "Feedback"
   },
   {
-    "slug": "statuscode",
-    "name": "HTTP Status Code",
-    "description": "An HTTP status code display for building 404 and error pages.",
-    "category": "Feedback"
-  },
-  {
     "slug": "swipe-to-delete",
     "name": "Swipe to Delete",
     "description": "A swipeable list item that reveals an iOS-style delete action on drag.",
-    "category": "Action"
+    "category": "Action",
+    "new": true
   },
   {
     "slug": "task-checkbox",
     "name": "Task Checkbox",
     "description": "A todo checkbox that celebrates completion with a confetti burst and strikethrough.",
-    "category": "Form"
-  },
-  {
-    "slug": "testimonials",
-    "name": "Testimonials",
-    "description": "A testimonials section for showcasing customer reviews and social proof.",
-    "category": "Content"
+    "category": "Form",
+    "new": true
   },
   {
     "slug": "tilt-card",
     "name": "3D Tilt Card",
     "description": "A 3D card that tilts toward the pointer with parallax depth and glare.",
-    "category": "Card"
+    "category": "Card",
+    "new": true
   },
   {
     "slug": "undo-pill",
     "name": "Undo Pill",
     "description": "An inline undo pill with a draining countdown ring that pauses on hover.",
-    "category": "Feedback"
+    "category": "Feedback",
+    "new": true
   }
 ]

--- a/content/component-docs.json
+++ b/content/component-docs.json
@@ -57,19 +57,19 @@
         "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars."
       },
       {
-        "slug": "command-palette",
-        "name": "Command Palette",
-        "description": "A keyboard-driven command menu for navigation, actions, and theme switching."
+        "slug": "alert",
+        "name": "Animated Alert",
+        "description": "An animated alert that displays notifications, warnings, and success messages."
       },
       {
-        "slug": "dock",
-        "name": "Dock Menu",
-        "description": "A macOS-style dock menu that magnifies icons on hover with tooltips."
+        "slug": "animated-switch",
+        "name": "Animated Switch",
+        "description": "An iOS-style toggle switch with a stretchy knob you can drag or flick."
       },
       {
-        "slug": "navbar",
-        "name": "Navbar",
-        "description": "A collection of responsive navbars with circular, tab, floating, and sidebar patterns."
+        "slug": "animatedcard",
+        "name": "Animated Card",
+        "description": "A card that animates on hover to showcase tools, technologies, and features."
       }
     ],
     "faqs": [
@@ -191,9 +191,9 @@
         "description": "A Slack-style emoji reaction bar with animated chips and rolling counts."
       },
       {
-        "slug": "skeleton",
-        "name": "Skeleton",
-        "description": "A loading placeholder that shimmer-animates while content is fetching."
+        "slug": "spinner",
+        "name": "Spinner",
+        "description": "A loading spinner with multiple sizes and variants for async states."
       }
     ],
     "faqs": [
@@ -446,19 +446,19 @@
         "description": "A set of pre-designed cards for login, signup, pricing, and dashboards."
       },
       {
-        "slug": "product-card",
-        "name": "Product Card",
-        "description": "A product card that displays an image, title, price, and rating."
-      },
-      {
         "slug": "tilt-card",
         "name": "3D Tilt Card",
         "description": "A 3D card that tilts toward the pointer with parallax depth and glare."
       },
       {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
+      },
+      {
+        "slug": "badge",
+        "name": "3D Event Badge",
+        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
       }
     ],
     "faqs": [
@@ -560,9 +560,9 @@
         "description": "An animated alert that displays notifications, warnings, and success messages."
       },
       {
-        "slug": "eventcalendar",
-        "name": "Event Calendar",
-        "description": "An interactive calendar for displaying events, appointments, and daily schedules."
+        "slug": "feedback",
+        "name": "Feedback Card",
+        "description": "A feedback card that collects ratings and comments with emoji reactions."
       }
     ],
     "faqs": [
@@ -597,6 +597,7 @@
     "name": "Animated Drawer",
     "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars.",
     "category": "Overlay",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -653,24 +654,24 @@
     ],
     "related": [
       {
-        "slug": "responsive-modal",
-        "name": "Responsive Modal",
-        "description": "A dialog that centers on desktop and slides up as a sheet on mobile."
-      },
-      {
         "slug": "accordion",
         "name": "Accordion",
         "description": "A vertically stacked set of interactive headings that each reveal a section of content."
       },
       {
-        "slug": "command-palette",
-        "name": "Command Palette",
-        "description": "A keyboard-driven command menu for navigation, actions, and theme switching."
+        "slug": "alert",
+        "name": "Animated Alert",
+        "description": "An animated alert that displays notifications, warnings, and success messages."
       },
       {
-        "slug": "dock",
-        "name": "Dock Menu",
-        "description": "A macOS-style dock menu that magnifies icons on hover with tooltips."
+        "slug": "animated-switch",
+        "name": "Animated Switch",
+        "description": "An iOS-style toggle switch with a stretchy knob you can drag or flick."
+      },
+      {
+        "slug": "animatedcard",
+        "name": "Animated Card",
+        "description": "A card that animates on hover to showcase tools, technologies, and features."
       }
     ],
     "faqs": [
@@ -697,305 +698,6 @@
       {
         "question": "What accessibility checks should I run for Animated Drawer?",
         "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
-    "slug": "animatedtestimonials",
-    "name": "Animated Testimonials",
-    "description": "An animated testimonials section for showcasing customer reviews and social proof.",
-    "category": "Review",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "framer-motion",
-      "lucide-react"
-    ],
-    "registryDependencies": [
-      "button"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/animated-testimonials"
-      ],
-      "dependencyCommands": [
-        "npm i lucide-react framer-motion"
-      ],
-      "manualPaths": [
-        "app/(docs)/docs/animatedtestimonials/usages/demousages.tsx",
-        "components/spectrumui/animated_testimonials.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need an animated testimonials section for showcasing customer reviews and social proof",
-      "landing pages",
-      "case-study pages"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: button",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtext",
-        "name": "Text Animations",
-        "description": "A collection of text effects including holographic, ink morph, and orbital reveals."
-      },
-      {
-        "slug": "avatar-stack",
-        "name": "Avatar Stack",
-        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
-      },
-      {
-        "slug": "badge",
-        "name": "3D Event Badge",
-        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Animated Testimonials free to use in commercial projects?",
-        "answer": "Yes. The public Animated Testimonials source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Animated Testimonials?",
-        "answer": "Run npx shadcn@latest add @spectrumui/animated-testimonials. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Animated Testimonials require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Animated Testimonials."
-      },
-      {
-        "question": "Does Animated Testimonials use shadcn/ui or Radix UI?",
-        "answer": "Animated Testimonials uses the button shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Animated Testimonials in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Animated Testimonials?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
-    "slug": "animatedtext",
-    "name": "Text Animations",
-    "description": "A collection of text effects including holographic, ink morph, and orbital reveals.",
-    "category": "Text",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui"
-    ],
-    "dependencies": [
-      "next-themes",
-      "framer-motion"
-    ],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/holographic",
-        "npx shadcn@latest add @spectrumui/orbital-letters",
-        "npx shadcn@latest add @spectrumui/ink"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "app/(docs)/docs/animatedtext/usage/holo.tsx",
-        "app/(docs)/docs/animatedtext/usage/orbital.tsx",
-        "app/(docs)/docs/animatedtext/usage/ink.tsx",
-        "components/spectrumui/hologram-text.tsx",
-        "components/spectrumui/orbital-text.tsx",
-        "components/spectrumui/orbital-char.tsx",
-        "components/spectrumui/ink-morph.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [
-      {
-        "name": "text",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the text property in the exported source type."
-      },
-      {
-        "name": "scanDuration",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the scanDuration property in the exported source type."
-      },
-      {
-        "name": "chromaJitter",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the chromaJitter property in the exported source type."
-      },
-      {
-        "name": "radius",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the radius property in the exported source type."
-      },
-      {
-        "name": "duration",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the duration property in the exported source type."
-      },
-      {
-        "name": "decay",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the decay property in the exported source type."
-      },
-      {
-        "name": "char",
-        "type": "string",
-        "required": true,
-        "description": "Value accepted by the char property in the exported source type."
-      },
-      {
-        "name": "index",
-        "type": "number",
-        "required": true,
-        "description": "Value accepted by the index property in the exported source type."
-      },
-      {
-        "name": "intensityFrom",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the intensityFrom property in the exported source type."
-      },
-      {
-        "name": "intensityTo",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the intensityTo property in the exported source type."
-      },
-      {
-        "name": "settleMs",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the settleMs property in the exported source type."
-      },
-      {
-        "name": "colorStart",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the colorStart property in the exported source type."
-      },
-      {
-        "name": "colorEnd",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the colorEnd property in the exported source type."
-      }
-    ],
-    "useCases": [
-      "interfaces that need a collection of text effects including holographic, ink morph, and orbital reveals",
-      "landing-page headings",
-      "product launches"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: local UI primitives"
-    ],
-    "accessibility": [
-      "The source includes ARIA attributes or roles; preserve them when customizing the component.",
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "heading-with-anchor",
-        "name": "Heading With Anchor",
-        "description": "A heading component that adds clickable anchor links for section sharing."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      },
-      {
-        "slug": "avatar-stack",
-        "name": "Avatar Stack",
-        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Text Animations free to use in commercial projects?",
-        "answer": "Yes. The public Text Animations source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Text Animations?",
-        "answer": "Run npx shadcn@latest add @spectrumui/holographic or npx shadcn@latest add @spectrumui/orbital-letters or npx shadcn@latest add @spectrumui/ink. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Text Animations require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Text Animations."
-      },
-      {
-        "question": "Does Text Animations use shadcn/ui or Radix UI?",
-        "answer": "Text Animations uses local shadcn/ui primitives."
-      },
-      {
-        "question": "Can I use Text Animations in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Text Animations?",
-        "answer": "The source includes ARIA markup. Test the finished interface with keyboard and screen-reader workflows."
       }
     ]
   },
@@ -1099,9 +801,9 @@
         "description": "An input whose label floats above the field when focused or filled."
       },
       {
-        "slug": "input",
-        "name": "Input",
-        "description": "A form input field or a component that looks like an input field."
+        "slug": "input-model",
+        "name": "Input Model",
+        "description": "A modal dialog with an input form for quick data entry."
       }
     ],
     "faqs": [
@@ -1136,6 +838,7 @@
     "name": "Avatar Stack",
     "description": "An overlapping avatar row that fans apart on hover with springy name tooltips.",
     "category": "Profile",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -1226,11 +929,6 @@
     ],
     "related": [
       {
-        "slug": "github-card",
-        "name": "GitHub Profile Card",
-        "description": "A GitHub profile card generator with stats, a contribution graph, and social links."
-      },
-      {
         "slug": "profile",
         "name": "Profile Dropdown",
         "description": "A user profile dropdown menu with avatar, settings, and logout actions."
@@ -1241,9 +939,14 @@
         "description": "A card that animates on hover to showcase tools, technologies, and features."
       },
       {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
+        "slug": "badge",
+        "name": "3D Event Badge",
+        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
+      },
+      {
+        "slug": "card",
+        "name": "Card",
+        "description": "A set of pre-designed cards for login, signup, pricing, and dashboards."
       }
     ],
     "faqs": [
@@ -1360,11 +1063,6 @@
     ],
     "related": [
       {
-        "slug": "discloseimage",
-        "name": "Disclose Image",
-        "description": "An image that reveals its content behind animated sliding door panels."
-      },
-      {
         "slug": "imagepreview",
         "name": "Image Preview",
         "description": "An image preview component with zoom, lightbox, and gallery support."
@@ -1378,6 +1076,11 @@
         "slug": "animatedcard",
         "name": "Animated Card",
         "description": "A card that animates on hover to showcase tools, technologies, and features."
+      },
+      {
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
       }
     ],
     "faqs": [
@@ -1403,228 +1106,6 @@
       },
       {
         "question": "What accessibility checks should I run for 3D Event Badge?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
-    "slug": "bento-grid",
-    "name": "Bento Grid",
-    "description": "A bento grid layout with physics-based hover effects and scroll animations.",
-    "category": "Layout",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion"
-    ],
-    "dependencies": [
-      "framer-motion",
-      "lucide-react"
-    ],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/bento-grid"
-      ],
-      "dependencyCommands": [
-        "npm install framer-motion lucide-react"
-      ],
-      "manualPaths": [
-        "app/registry/bento-grid/bento-grid.tsx",
-        "components/spectrumui/bento-grid.tsx",
-        "components/spectrumui/bento-card.tsx",
-        "components/spectrumui/spotlight.tsx",
-        "components/spectrumui/border-beam.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [
-      {
-        "name": "className",
-        "type": "string",
-        "required": false,
-        "description": "Additional classes accepted by the component source."
-      },
-      {
-        "name": "children",
-        "type": "ReactNode",
-        "required": false,
-        "description": "Content rendered inside the component."
-      },
-      {
-        "name": "title",
-        "type": "ReactNode",
-        "required": false,
-        "description": "Value accepted by the title property in the exported source type."
-      },
-      {
-        "name": "description",
-        "type": "ReactNode",
-        "required": false,
-        "description": "Value accepted by the description property in the exported source type."
-      },
-      {
-        "name": "icon",
-        "type": "ReactNode",
-        "required": false,
-        "description": "Value accepted by the icon property in the exported source type."
-      },
-      {
-        "name": "background",
-        "type": "ReactNode",
-        "required": false,
-        "description": "Value accepted by the background property in the exported source type."
-      },
-      {
-        "name": "colSpan",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the colSpan property in the exported source type."
-      },
-      {
-        "name": "rowSpan",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the rowSpan property in the exported source type."
-      },
-      {
-        "name": "tilt",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the tilt property in the exported source type."
-      },
-      {
-        "name": "spotlight",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the spotlight property in the exported source type."
-      },
-      {
-        "name": "borderAnim",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the borderAnim property in the exported source type."
-      },
-      {
-        "name": "mouseX",
-        "type": "MotionValue<number>",
-        "required": true,
-        "description": "Value accepted by the mouseX property in the exported source type."
-      },
-      {
-        "name": "mouseY",
-        "type": "MotionValue<number>",
-        "required": true,
-        "description": "Value accepted by the mouseY property in the exported source type."
-      },
-      {
-        "name": "isHovered",
-        "type": "boolean",
-        "required": true,
-        "description": "Value accepted by the isHovered property in the exported source type."
-      },
-      {
-        "name": "color",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the color property in the exported source type."
-      },
-      {
-        "name": "duration",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the duration property in the exported source type."
-      },
-      {
-        "name": "borderWidth",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the borderWidth property in the exported source type."
-      },
-      {
-        "name": "colorFrom",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the colorFrom property in the exported source type."
-      },
-      {
-        "name": "colorTo",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the colorTo property in the exported source type."
-      }
-    ],
-    "useCases": [
-      "interfaces that need a bento grid layout with physics-based hover effects and scroll animations",
-      "dashboard layouts",
-      "landing pages"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "footer",
-        "name": "Footer",
-        "description": "A collection of footers with wave, stacked, and particle animation styles."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      },
-      {
-        "slug": "animatedtext",
-        "name": "Text Animations",
-        "description": "A collection of text effects including holographic, ink morph, and orbital reveals."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Bento Grid free to use in commercial projects?",
-        "answer": "Yes. The public Bento Grid source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Bento Grid?",
-        "answer": "Run npx shadcn@latest add @spectrumui/bento-grid. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Bento Grid require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Bento Grid."
-      },
-      {
-        "question": "Does Bento Grid use shadcn/ui or Radix UI?",
-        "answer": "No shadcn/ui or Radix UI dependency was detected in the documented Bento Grid source."
-      },
-      {
-        "question": "Can I use Bento Grid in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Bento Grid?",
         "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
       }
     ]
@@ -1781,19 +1262,19 @@
         "description": "A card that animates on hover to showcase tools, technologies, and features."
       },
       {
-        "slug": "product-card",
-        "name": "Product Card",
-        "description": "A product card that displays an image, title, price, and rating."
-      },
-      {
         "slug": "tilt-card",
         "name": "3D Tilt Card",
         "description": "A 3D card that tilts toward the pointer with parallax depth and glare."
       },
       {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
+      },
+      {
+        "slug": "badge",
+        "name": "3D Event Badge",
+        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
       }
     ],
     "faqs": [
@@ -1820,133 +1301,6 @@
       {
         "question": "What accessibility checks should I run for Card?",
         "answer": "The source includes ARIA markup, keyboard handlers. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
-    "slug": "command-palette",
-    "name": "Command Palette",
-    "description": "A keyboard-driven command menu for navigation, actions, and theme switching.",
-    "category": "Navigation",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "framer-motion",
-      "lucide-react",
-      "next-themes"
-    ],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/command-palette"
-      ],
-      "dependencyCommands": [
-        "npm i framer-motion lucide-react next-themes"
-      ],
-      "manualPaths": [
-        "components/spectrumui/command-palette.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [
-      {
-        "name": "isOpen",
-        "type": "boolean",
-        "required": true,
-        "description": "Value accepted by the isOpen property in the exported source type."
-      },
-      {
-        "name": "onClose",
-        "type": "() => void",
-        "required": true,
-        "description": "Callback exposed by the component source."
-      },
-      {
-        "name": "className",
-        "type": "string",
-        "required": false,
-        "description": "Additional classes accepted by the component source."
-      }
-    ],
-    "useCases": [
-      "interfaces that need a keyboard-driven command menu for navigation, actions, and theme switching",
-      "application shells",
-      "dashboards"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: local UI primitives",
-      "Responsive Tailwind variants present in the source",
-      "Reduced-motion handling present in the source"
-    ],
-    "accessibility": [
-      "The source checks reduced-motion preferences or includes motion-reduce styles.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "dock",
-        "name": "Dock Menu",
-        "description": "A macOS-style dock menu that magnifies icons on hover with tooltips."
-      },
-      {
-        "slug": "navbar",
-        "name": "Navbar",
-        "description": "A collection of responsive navbars with circular, tab, floating, and sidebar patterns."
-      },
-      {
-        "slug": "accordion",
-        "name": "Accordion",
-        "description": "A vertically stacked set of interactive headings that each reveal a section of content."
-      },
-      {
-        "slug": "animateddrawer",
-        "name": "Animated Drawer",
-        "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Command Palette free to use in commercial projects?",
-        "answer": "Yes. The public Command Palette source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Command Palette?",
-        "answer": "Run npx shadcn@latest add @spectrumui/command-palette. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Command Palette require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Command Palette."
-      },
-      {
-        "question": "Does Command Palette use shadcn/ui or Radix UI?",
-        "answer": "Command Palette uses local shadcn/ui primitives."
-      },
-      {
-        "question": "Can I use Command Palette in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Command Palette?",
-        "answer": "The source includes reduced-motion handling. Test the finished interface with keyboard and screen-reader workflows."
       }
     ]
   },
@@ -2139,9 +1493,9 @@
         "description": "An input whose label floats above the field when focused or filled."
       },
       {
-        "slug": "input",
-        "name": "Input",
-        "description": "A form input field or a component that looks like an input field."
+        "slug": "input-model",
+        "name": "Input Model",
+        "description": "A modal dialog with an input form for quick data entry."
       }
     ],
     "faqs": [
@@ -2167,267 +1521,6 @@
       },
       {
         "question": "What accessibility checks should I run for Datetime Picker?",
-        "answer": "The source includes ARIA markup, keyboard handlers. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
-    "slug": "discloseimage",
-    "name": "Disclose Image",
-    "description": "An image that reveals its content behind animated sliding door panels.",
-    "category": "Media",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS"
-    ],
-    "dependencies": [],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/disclose-image"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/spectrumui/discloseimage.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [
-      {
-        "name": "doorClassName",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the doorClassName property in the exported source type."
-      },
-      {
-        "name": "vertical",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the vertical property in the exported source type."
-      }
-    ],
-    "useCases": [
-      "interfaces that need an image that reveals its content behind animated sliding door panels",
-      "landing pages",
-      "portfolio pages"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "badge",
-        "name": "3D Event Badge",
-        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
-      },
-      {
-        "slug": "imagepreview",
-        "name": "Image Preview",
-        "description": "An image preview component with zoom, lightbox, and gallery support."
-      },
-      {
-        "slug": "scratch-card",
-        "name": "Scratch Card",
-        "description": "A scratch-to-reveal card that wipes away a canvas foil overlay on drag."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Disclose Image free to use in commercial projects?",
-        "answer": "Yes. The public Disclose Image source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Disclose Image?",
-        "answer": "Run npx shadcn@latest add @spectrumui/disclose-image. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Disclose Image require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Disclose Image."
-      },
-      {
-        "question": "Does Disclose Image use shadcn/ui or Radix UI?",
-        "answer": "No shadcn/ui or Radix UI dependency was detected in the documented Disclose Image source."
-      },
-      {
-        "question": "Can I use Disclose Image in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Disclose Image?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
-    "slug": "dock",
-    "name": "Dock Menu",
-    "description": "A macOS-style dock menu that magnifies icons on hover with tooltips.",
-    "category": "Navigation",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui"
-    ],
-    "dependencies": [
-      "lucide-react",
-      "framer-motion"
-    ],
-    "registryDependencies": [
-      "@spectrumui/dock"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/dock-demo",
-        "npx shadcn@latest add @spectrumui/dock-glass"
-      ],
-      "dependencyCommands": [
-        "npm i framer-motion"
-      ],
-      "manualPaths": [
-        "components/ui/dock.tsx",
-        "components/spectrumui/dock-demo.tsx",
-        "components/spectrumui/dock-glass.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": true
-    },
-    "props": [
-      {
-        "name": "children",
-        "type": "React.ReactNode",
-        "required": true,
-        "description": "Content rendered inside the component."
-      },
-      {
-        "name": "className",
-        "type": "string",
-        "required": false,
-        "description": "Additional classes accepted by the component source."
-      },
-      {
-        "name": "magnification",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the magnification property in the exported source type."
-      },
-      {
-        "name": "distance",
-        "type": "number",
-        "required": false,
-        "description": "Value accepted by the distance property in the exported source type."
-      },
-      {
-        "name": "variant",
-        "type": "\"normal\" | \"glass\"",
-        "required": false,
-        "description": "Value accepted by the variant property in the exported source type."
-      },
-      {
-        "name": "label",
-        "type": "string",
-        "required": true,
-        "description": "Value accepted by the label property in the exported source type."
-      },
-      {
-        "name": "onClick",
-        "type": "() => void",
-        "required": false,
-        "description": "Callback exposed by the component source."
-      }
-    ],
-    "useCases": [
-      "interfaces that need a macOS-style dock menu that magnifies icons on hover with tooltips",
-      "application shells",
-      "dashboards"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: local UI primitives",
-      "Spectrum UI registry dependencies: @spectrumui/dock"
-    ],
-    "accessibility": [
-      "The source includes ARIA attributes or roles; preserve them when customizing the component.",
-      "The source includes keyboard event handling; verify it alongside pointer behavior.",
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "command-palette",
-        "name": "Command Palette",
-        "description": "A keyboard-driven command menu for navigation, actions, and theme switching."
-      },
-      {
-        "slug": "navbar",
-        "name": "Navbar",
-        "description": "A collection of responsive navbars with circular, tab, floating, and sidebar patterns."
-      },
-      {
-        "slug": "accordion",
-        "name": "Accordion",
-        "description": "A vertically stacked set of interactive headings that each reveal a section of content."
-      },
-      {
-        "slug": "animateddrawer",
-        "name": "Animated Drawer",
-        "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Dock Menu free to use in commercial projects?",
-        "answer": "Yes. The public Dock Menu source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Dock Menu?",
-        "answer": "Run npx shadcn@latest add @spectrumui/dock-demo or npx shadcn@latest add @spectrumui/dock-glass. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Dock Menu require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Dock Menu."
-      },
-      {
-        "question": "Does Dock Menu use shadcn/ui or Radix UI?",
-        "answer": "Dock Menu uses local shadcn/ui primitives."
-      },
-      {
-        "question": "Can I use Dock Menu in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Dock Menu?",
         "answer": "The source includes ARIA markup, keyboard handlers. Test the finished interface with keyboard and screen-reader workflows."
       }
     ]
@@ -2524,9 +1617,9 @@
         "description": "An input whose label floats above the field when focused or filled."
       },
       {
-        "slug": "input",
-        "name": "Input",
-        "description": "A form input field or a component that looks like an input field."
+        "slug": "input-model",
+        "name": "Input Model",
+        "description": "A modal dialog with an input form for quick data entry."
       }
     ],
     "faqs": [
@@ -2557,122 +1650,11 @@
     ]
   },
   {
-    "slug": "eventcalendar",
-    "name": "Event Calendar",
-    "description": "An interactive calendar for displaying events, appointments, and daily schedules.",
-    "category": "Calendar",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "framer-motion",
-      "lucide-react",
-      "date-fns"
-    ],
-    "registryDependencies": [
-      "button",
-      "dialog",
-      "input",
-      "label"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/event-calendar"
-      ],
-      "dependencyCommands": [
-        "npm i lucide-react framer-motion date-fns"
-      ],
-      "manualPaths": [
-        "lib/utils.ts",
-        "components/spectrumui/event-calendar"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need an interactive calendar for displaying events, appointments, and daily schedules",
-      "scheduling dashboards",
-      "booking flows"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: button, dialog, input, label"
-    ],
-    "accessibility": [
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "alert",
-        "name": "Animated Alert",
-        "description": "An animated alert that displays notifications, warnings, and success messages."
-      },
-      {
-        "slug": "animatedchart",
-        "name": "Animated SVG Chart",
-        "description": "An animated SVG chart for visualizing data on dashboards and reports."
-      },
-      {
-        "slug": "feedback",
-        "name": "Feedback Card",
-        "description": "A feedback card that collects ratings and comments with emoji reactions."
-      },
-      {
-        "slug": "infinite-scroll",
-        "name": "Infinite Scroll",
-        "description": "An infinite scroll container that loads more content using the IntersectionObserver API."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Event Calendar free to use in commercial projects?",
-        "answer": "Yes. The public Event Calendar source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Event Calendar?",
-        "answer": "Run npx shadcn@latest add @spectrumui/event-calendar. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Event Calendar require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Event Calendar."
-      },
-      {
-        "question": "Does Event Calendar use shadcn/ui or Radix UI?",
-        "answer": "Event Calendar uses the button, dialog, input, label shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Event Calendar in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Event Calendar?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "face-rating",
     "name": "Face Rating",
     "description": "A five-level rating input where an SVG face morphs between moods.",
     "category": "Rating",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -2895,9 +1877,9 @@
         "description": "A Slack-style emoji reaction bar with animated chips and rolling counts."
       },
       {
-        "slug": "skeleton",
-        "name": "Skeleton",
-        "description": "A loading placeholder that shimmer-animates while content is fetching."
+        "slug": "spinner",
+        "name": "Spinner",
+        "description": "A loading spinner with multiple sizes and variants for async states."
       }
     ],
     "faqs": [
@@ -3006,9 +1988,9 @@
         "description": "A slider with two draggable thumbs for selecting a range of values."
       },
       {
-        "slug": "input",
-        "name": "Input",
-        "description": "A form input field or a component that looks like an input field."
+        "slug": "input-model",
+        "name": "Input Model",
+        "description": "A modal dialog with an input form for quick data entry."
       }
     ],
     "faqs": [
@@ -3043,6 +2025,7 @@
     "name": "Follow Button",
     "description": "A follow button that morphs its width, fill, and label between states.",
     "category": "Action",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -3199,392 +2182,11 @@
     ]
   },
   {
-    "slug": "footer",
-    "name": "Footer",
-    "description": "A collection of footers with wave, stacked, and particle animation styles.",
-    "category": "Layout",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "lucide-react"
-    ],
-    "registryDependencies": [
-      "button",
-      "input",
-      "label",
-      "switch",
-      "textarea",
-      "tooltip",
-      "icon",
-      "@spectrumui/icon-dependencies"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/footers-demo",
-        "npx shadcn@latest add @spectrumui/stackedcircular-footer",
-        "npx shadcn@latest add @spectrumui/floatingparticle-footer",
-        "npx shadcn@latest add @spectrumui/footer"
-      ],
-      "dependencyCommands": [
-        "npm i lucide-react"
-      ],
-      "manualPaths": [
-        "app/(docs)/docs/footer/footerdemo.tsx",
-        "components/spectrumui/footer-demo.tsx",
-        "components/spectrumui/stacked-footer.tsx",
-        "components/spectrumui/floatingparticle-footer.tsx",
-        "components/spectrumui/footer.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a collection of footers with wave, stacked, and particle animation styles",
-      "dashboard layouts",
-      "landing pages"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: button, input, label, switch, textarea, tooltip, icon",
-      "Spectrum UI registry dependencies: @spectrumui/icon-dependencies",
-      "Responsive Tailwind variants present in the source",
-      "Reduced-motion handling present in the source"
-    ],
-    "accessibility": [
-      "The source includes ARIA attributes or roles; preserve them when customizing the component.",
-      "The source checks reduced-motion preferences or includes motion-reduce styles.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "bento-grid",
-        "name": "Bento Grid",
-        "description": "A bento grid layout with physics-based hover effects and scroll animations."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      },
-      {
-        "slug": "animatedtext",
-        "name": "Text Animations",
-        "description": "A collection of text effects including holographic, ink morph, and orbital reveals."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Footer free to use in commercial projects?",
-        "answer": "Yes. The public Footer source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Footer?",
-        "answer": "Run npx shadcn@latest add @spectrumui/footers-demo or npx shadcn@latest add @spectrumui/stackedcircular-footer or npx shadcn@latest add @spectrumui/floatingparticle-footer or npx shadcn@latest add @spectrumui/footer. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Footer require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Footer."
-      },
-      {
-        "question": "Does Footer use shadcn/ui or Radix UI?",
-        "answer": "Footer uses the button, input, label, switch, textarea, tooltip, icon shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Footer in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Footer?",
-        "answer": "The source includes ARIA markup, reduced-motion handling. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
-    "slug": "github-card",
-    "name": "GitHub Profile Card",
-    "description": "A GitHub profile card generator with stats, a contribution graph, and social links.",
-    "category": "Profile",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui"
-    ],
-    "dependencies": [
-      "lucide-react"
-    ],
-    "registryDependencies": [
-      "avatar",
-      "button",
-      "card",
-      "input"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/github-profile-card"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/spectrumui/github-profile-card.tsx",
-        "components/icon.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a GitHub profile card generator with stats, a contribution graph, and social links",
-      "account pages",
-      "team directories"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: avatar, button, card, input"
-    ],
-    "accessibility": [
-      "The source includes ARIA attributes or roles; preserve them when customizing the component.",
-      "The source includes keyboard event handling; verify it alongside pointer behavior.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes."
-    ],
-    "related": [
-      {
-        "slug": "avatar-stack",
-        "name": "Avatar Stack",
-        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
-      },
-      {
-        "slug": "profile",
-        "name": "Profile Dropdown",
-        "description": "A user profile dropdown menu with avatar, settings, and logout actions."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is GitHub Profile Card free to use in commercial projects?",
-        "answer": "Yes. The public GitHub Profile Card source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install GitHub Profile Card?",
-        "answer": "Run npx shadcn@latest add @spectrumui/github-profile-card. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does GitHub Profile Card require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for GitHub Profile Card."
-      },
-      {
-        "question": "Does GitHub Profile Card use shadcn/ui or Radix UI?",
-        "answer": "GitHub Profile Card uses the avatar, button, card, input shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use GitHub Profile Card in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for GitHub Profile Card?",
-        "answer": "The source includes ARIA markup, keyboard handlers. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
-    "slug": "heading-with-anchor",
-    "name": "Heading With Anchor",
-    "description": "A heading component that adds clickable anchor links for section sharing.",
-    "category": "Text",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui",
-      "Radix UI"
-    ],
-    "dependencies": [
-      "@radix-ui/react-slot",
-      "class-variance-authority"
-    ],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/heading-with-anchor"
-      ],
-      "dependencyCommands": [
-        "npm i @radix-ui/react-slot class-variance-authority"
-      ],
-      "manualPaths": [
-        "components/ui/heading-with-anchor.tsx",
-        "components/spectrumui/heading-with-anchor.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": true
-    },
-    "props": [
-      {
-        "name": "anchor",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the anchor property in the exported source type."
-      },
-      {
-        "name": "anchorVisibility",
-        "type": "\"hover\" | \"always\" | \"never\"",
-        "required": false,
-        "description": "Value accepted by the anchorVisibility property in the exported source type."
-      },
-      {
-        "name": "disableCopyToClipboard",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the disableCopyToClipboard property in the exported source type."
-      },
-      {
-        "name": "children",
-        "type": "React.ReactNode",
-        "required": false,
-        "description": "Content rendered inside the component."
-      },
-      {
-        "name": "variant",
-        "type": "string",
-        "required": false,
-        "description": "Value accepted by the variant property in the exported source type."
-      },
-      {
-        "name": "className",
-        "type": "string",
-        "required": false,
-        "description": "Additional classes accepted by the component source."
-      },
-      {
-        "name": "asChild",
-        "type": "boolean",
-        "required": false,
-        "description": "Value accepted by the asChild property in the exported source type."
-      },
-      {
-        "name": "anchorAlignment",
-        "type": "\"close\" | \"spaced\"",
-        "required": false,
-        "description": "Value accepted by the anchorAlignment property in the exported source type."
-      }
-    ],
-    "useCases": [
-      "interfaces that need a heading component that adds clickable anchor links for section sharing",
-      "landing-page headings",
-      "product launches"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: local UI primitives",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "The source uses Radix UI primitives for the interactions detected on this component.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "animatedtext",
-        "name": "Text Animations",
-        "description": "A collection of text effects including holographic, ink morph, and orbital reveals."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      },
-      {
-        "slug": "avatar-stack",
-        "name": "Avatar Stack",
-        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Heading With Anchor free to use in commercial projects?",
-        "answer": "Yes. The public Heading With Anchor source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Heading With Anchor?",
-        "answer": "Run npx shadcn@latest add @spectrumui/heading-with-anchor. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Heading With Anchor require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Heading With Anchor."
-      },
-      {
-        "question": "Does Heading With Anchor use shadcn/ui or Radix UI?",
-        "answer": "Heading With Anchor uses local shadcn/ui primitives and imports Radix UI directly."
-      },
-      {
-        "question": "Can I use Heading With Anchor in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Heading With Anchor?",
-        "answer": "The source includes Radix UI primitives. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
     "slug": "hold-to-confirm",
     "name": "Hold to Confirm",
     "description": "A press-and-hold button that fills a progress ring before confirming destructive actions.",
     "category": "Action",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -3832,11 +2434,6 @@
         "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
       },
       {
-        "slug": "discloseimage",
-        "name": "Disclose Image",
-        "description": "An image that reveals its content behind animated sliding door panels."
-      },
-      {
         "slug": "scratch-card",
         "name": "Scratch Card",
         "description": "A scratch-to-reveal card that wipes away a canvas foil overlay on drag."
@@ -3845,6 +2442,11 @@
         "slug": "animatedcard",
         "name": "Animated Card",
         "description": "A card that animates on hover to showcase tools, technologies, and features."
+      },
+      {
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
       }
     ],
     "faqs": [
@@ -3990,9 +2592,9 @@
         "description": "An animated alert that displays notifications, warnings, and success messages."
       },
       {
-        "slug": "eventcalendar",
-        "name": "Event Calendar",
-        "description": "An interactive calendar for displaying events, appointments, and daily schedules."
+        "slug": "feedback",
+        "name": "Feedback Card",
+        "description": "A feedback card that collects ratings and comments with emoji reactions."
       }
     ],
     "faqs": [
@@ -4018,102 +2620,6 @@
       },
       {
         "question": "What accessibility checks should I run for Infinite Scroll?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
-    "slug": "input",
-    "name": "Input",
-    "description": "A form input field or a component that looks like an input field.",
-    "category": "Form",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui"
-    ],
-    "dependencies": [],
-    "registryDependencies": [],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add input"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/ui/input.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": true
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a form input field or a component that looks like an input field",
-      "authentication flows",
-      "settings forms"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: local UI primitives",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "autosize-textarea",
-        "name": "Autosize Textarea",
-        "description": "A textarea that automatically grows and shrinks to fit its content."
-      },
-      {
-        "slug": "datetime-picker",
-        "name": "Datetime Picker",
-        "description": "A date and time picker built on shadcn/ui with no extra dependencies."
-      },
-      {
-        "slug": "dual-range-slider",
-        "name": "Dual Range Slider",
-        "description": "A slider with two draggable thumbs for selecting a range of values."
-      },
-      {
-        "slug": "floating-label-input",
-        "name": "Floating Label Input",
-        "description": "An input whose label floats above the field when focused or filled."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Input free to use in commercial projects?",
-        "answer": "Yes. The public Input source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Input?",
-        "answer": "Run npx shadcn@latest add input. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Input require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Input."
-      },
-      {
-        "question": "Does Input use shadcn/ui or Radix UI?",
-        "answer": "Input uses local shadcn/ui primitives."
-      },
-      {
-        "question": "Can I use Input in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Input?",
         "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
       }
     ]
@@ -4303,9 +2809,9 @@
         "description": "An animated alert that displays notifications, warnings, and success messages."
       },
       {
-        "slug": "eventcalendar",
-        "name": "Event Calendar",
-        "description": "An interactive calendar for displaying events, appointments, and daily schedules."
+        "slug": "feedback",
+        "name": "Feedback Card",
+        "description": "A feedback card that collects ratings and comments with emoji reactions."
       }
     ],
     "faqs": [
@@ -4494,6 +3000,7 @@
     "name": "Like Button",
     "description": "A heart button that pops with a particle burst and rolling count.",
     "category": "Action",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -5454,130 +3961,11 @@
     ]
   },
   {
-    "slug": "navbar",
-    "name": "Navbar",
-    "description": "A collection of responsive navbars with circular, tab, floating, and sidebar patterns.",
-    "category": "Navigation",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "lucide-react"
-    ],
-    "registryDependencies": [
-      "button",
-      "scroll-area",
-      "sheet",
-      "avatar",
-      "input",
-      "label",
-      "navigation-menu",
-      "dropdown-menu",
-      "collapsible"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/navbar-demo",
-        "npx shadcn@latest add @spectrumui/circular-navbar",
-        "npx shadcn@latest add @spectrumui/tab-navbar",
-        "npx shadcn@latest add @spectrumui/floating-navbar",
-        "npx shadcn@latest add @spectrumui/sidebar-navbar"
-      ],
-      "dependencyCommands": [
-        "npm i lucide-react"
-      ],
-      "manualPaths": [
-        "app/(docs)/docs/navbar/navbardemo.tsx",
-        "components/spectrumui/navbar.tsx",
-        "components/spectrumui/circularnavbar.tsx",
-        "components/spectrumui/tabnavbar.tsx",
-        "components/spectrumui/floatingnavbar.tsx",
-        "components/spectrumui/sidebarnavbar.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a collection of responsive navbars with circular, tab, floating, and sidebar patterns",
-      "application shells",
-      "dashboards"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: button, scroll-area, sheet, avatar, input, label, navigation-menu, dropdown-menu, collapsible",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "command-palette",
-        "name": "Command Palette",
-        "description": "A keyboard-driven command menu for navigation, actions, and theme switching."
-      },
-      {
-        "slug": "dock",
-        "name": "Dock Menu",
-        "description": "A macOS-style dock menu that magnifies icons on hover with tooltips."
-      },
-      {
-        "slug": "accordion",
-        "name": "Accordion",
-        "description": "A vertically stacked set of interactive headings that each reveal a section of content."
-      },
-      {
-        "slug": "animateddrawer",
-        "name": "Animated Drawer",
-        "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Navbar free to use in commercial projects?",
-        "answer": "Yes. The public Navbar source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Navbar?",
-        "answer": "Run npx shadcn@latest add @spectrumui/navbar-demo or npx shadcn@latest add @spectrumui/circular-navbar or npx shadcn@latest add @spectrumui/tab-navbar or npx shadcn@latest add @spectrumui/floating-navbar or npx shadcn@latest add @spectrumui/sidebar-navbar. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Navbar require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Navbar."
-      },
-      {
-        "question": "Does Navbar use shadcn/ui or Radix UI?",
-        "answer": "Navbar uses the button, scroll-area, sheet, avatar, input, label, navigation-menu, dropdown-menu, collapsible shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Navbar in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Navbar?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "notification-bell",
     "name": "Notification Bell",
     "description": "A bell button that swings on new notifications with a rolling unread badge.",
     "category": "Feedback",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -5688,9 +4076,9 @@
         "description": "A Slack-style emoji reaction bar with animated chips and rolling counts."
       },
       {
-        "slug": "skeleton",
-        "name": "Skeleton",
-        "description": "A loading placeholder that shimmer-animates while content is fetching."
+        "slug": "spinner",
+        "name": "Spinner",
+        "description": "A loading spinner with multiple sizes and variants for async states."
       }
     ],
     "faqs": [
@@ -5725,6 +4113,7 @@
     "name": "Password Strength",
     "description": "A password input with an animated strength meter and requirements checklist.",
     "category": "Form",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -5911,111 +4300,6 @@
     ]
   },
   {
-    "slug": "product-card",
-    "name": "Product Card",
-    "description": "A product card that displays an image, title, price, and rating.",
-    "category": "Card",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "lucide-react",
-      "next-themes"
-    ],
-    "registryDependencies": [
-      "button",
-      "select",
-      "card"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/product-card"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "app/(docs)/docs/product-card/product-card.tsx",
-        "components/spectrumui/product-card.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a product card that displays an image, title, price, and rating",
-      "SaaS dashboards",
-      "product pages"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: button, select, card",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes."
-    ],
-    "related": [
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      },
-      {
-        "slug": "card",
-        "name": "Card",
-        "description": "A set of pre-designed cards for login, signup, pricing, and dashboards."
-      },
-      {
-        "slug": "tilt-card",
-        "name": "3D Tilt Card",
-        "description": "A 3D card that tilts toward the pointer with parallax depth and glare."
-      },
-      {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Product Card free to use in commercial projects?",
-        "answer": "Yes. The public Product Card source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Product Card?",
-        "answer": "Run npx shadcn@latest add @spectrumui/product-card. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Product Card require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Product Card."
-      },
-      {
-        "question": "Does Product Card use shadcn/ui or Radix UI?",
-        "answer": "Product Card uses the button, select, card shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Product Card in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Product Card?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "profile",
     "name": "Profile Dropdown",
     "description": "A user profile dropdown menu with avatar, settings, and logout actions.",
@@ -6078,19 +4362,19 @@
         "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
       },
       {
-        "slug": "github-card",
-        "name": "GitHub Profile Card",
-        "description": "A GitHub profile card generator with stats, a contribution graph, and social links."
-      },
-      {
         "slug": "animatedcard",
         "name": "Animated Card",
         "description": "A card that animates on hover to showcase tools, technologies, and features."
       },
       {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
+        "slug": "badge",
+        "name": "3D Event Badge",
+        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
+      },
+      {
+        "slug": "card",
+        "name": "Card",
+        "description": "A set of pre-designed cards for login, signup, pricing, and dashboards."
       }
     ],
     "faqs": [
@@ -6414,6 +4698,7 @@
     "name": "Reaction Bar",
     "description": "A Slack-style emoji reaction bar with animated chips and rolling counts.",
     "category": "Feedback",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -6525,9 +4810,9 @@
         "description": "A bell button that swings on new notifications with a rolling unread badge."
       },
       {
-        "slug": "skeleton",
-        "name": "Skeleton",
-        "description": "A loading placeholder that shimmer-animates while content is fetching."
+        "slug": "spinner",
+        "name": "Spinner",
+        "description": "A loading spinner with multiple sizes and variants for async states."
       }
     ],
     "faqs": [
@@ -6558,115 +4843,11 @@
     ]
   },
   {
-    "slug": "responsive-modal",
-    "name": "Responsive Modal",
-    "description": "A dialog that centers on desktop and slides up as a sheet on mobile.",
-    "category": "Overlay",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui",
-      "Radix UI"
-    ],
-    "dependencies": [],
-    "registryDependencies": [
-      "@spectrumui/responsive-modal-dependencies",
-      "button"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/responsive-modal",
-        "npx shadcn@latest add @spectrumui/responsive-modal-side"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/ui/responsive-modal.tsx",
-        "components/spectrumui/responsive-modal-demo.tsx",
-        "components/spectrumui/responsive-modal-side.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a dialog that centers on desktop and slides up as a sheet on mobile",
-      "settings workflows",
-      "mobile navigation"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: button",
-      "Spectrum UI registry dependencies: @spectrumui/responsive-modal-dependencies",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "The source uses Radix UI primitives for the interactions detected on this component.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "animateddrawer",
-        "name": "Animated Drawer",
-        "description": "A drawer panel that slides in smoothly for menus, settings, and sidebars."
-      },
-      {
-        "slug": "accordion",
-        "name": "Accordion",
-        "description": "A vertically stacked set of interactive headings that each reveal a section of content."
-      },
-      {
-        "slug": "command-palette",
-        "name": "Command Palette",
-        "description": "A keyboard-driven command menu for navigation, actions, and theme switching."
-      },
-      {
-        "slug": "dock",
-        "name": "Dock Menu",
-        "description": "A macOS-style dock menu that magnifies icons on hover with tooltips."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Responsive Modal free to use in commercial projects?",
-        "answer": "Yes. The public Responsive Modal source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Responsive Modal?",
-        "answer": "Run npx shadcn@latest add @spectrumui/responsive-modal or npx shadcn@latest add @spectrumui/responsive-modal-side. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Responsive Modal require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Responsive Modal."
-      },
-      {
-        "question": "Does Responsive Modal use shadcn/ui or Radix UI?",
-        "answer": "Responsive Modal uses the button shadcn/ui dependencies and imports Radix UI directly."
-      },
-      {
-        "question": "Can I use Responsive Modal in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Responsive Modal?",
-        "answer": "The source includes Radix UI primitives. Test the finished interface with keyboard and screen-reader workflows."
-      }
-    ]
-  },
-  {
     "slug": "scratch-card",
     "name": "Scratch Card",
     "description": "A scratch-to-reveal card that wipes away a canvas foil overlay on drag.",
     "category": "Media",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -6798,11 +4979,6 @@
         "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
       },
       {
-        "slug": "discloseimage",
-        "name": "Disclose Image",
-        "description": "An image that reveals its content behind animated sliding door panels."
-      },
-      {
         "slug": "imagepreview",
         "name": "Image Preview",
         "description": "An image preview component with zoom, lightbox, and gallery support."
@@ -6811,6 +4987,11 @@
         "slug": "animatedcard",
         "name": "Animated Card",
         "description": "A card that animates on hover to showcase tools, technologies, and features."
+      },
+      {
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
       }
     ],
     "faqs": [
@@ -6990,106 +5171,6 @@
     ]
   },
   {
-    "slug": "skeleton",
-    "name": "Skeleton",
-    "description": "A loading placeholder that shimmer-animates while content is fetching.",
-    "category": "Feedback",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui"
-    ],
-    "dependencies": [],
-    "registryDependencies": [
-      "skeleton"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/skeleton",
-        "npx shadcn@latest add @spectrumui/skeleton-card"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/ui/skeleton.tsx",
-        "components/spectrumui/skeleton-demo.tsx",
-        "components/spectrumui/skeleton-card.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": true,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a loading placeholder that shimmer-animates while content is fetching",
-      "form workflows",
-      "support tools"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: skeleton"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Use the documented className surface for local layout adjustments, then edit the source for structural changes."
-    ],
-    "related": [
-      {
-        "slug": "alert",
-        "name": "Animated Alert",
-        "description": "An animated alert that displays notifications, warnings, and success messages."
-      },
-      {
-        "slug": "feedback",
-        "name": "Feedback Card",
-        "description": "A feedback card that collects ratings and comments with emoji reactions."
-      },
-      {
-        "slug": "notification-bell",
-        "name": "Notification Bell",
-        "description": "A bell button that swings on new notifications with a rolling unread badge."
-      },
-      {
-        "slug": "reaction-bar",
-        "name": "Reaction Bar",
-        "description": "A Slack-style emoji reaction bar with animated chips and rolling counts."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Skeleton free to use in commercial projects?",
-        "answer": "Yes. The public Skeleton source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Skeleton?",
-        "answer": "Run npx shadcn@latest add @spectrumui/skeleton or npx shadcn@latest add @spectrumui/skeleton-card. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Skeleton require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for Skeleton."
-      },
-      {
-        "question": "Does Skeleton use shadcn/ui or Radix UI?",
-        "answer": "Skeleton uses the skeleton shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Skeleton in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Skeleton?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "spinner",
     "name": "Spinner",
     "description": "A loading spinner with multiple sizes and variants for async states.",
@@ -7212,6 +5293,7 @@
     "name": "Star Rating",
     "description": "An animated star rating input with hover preview and sparkle burst effects.",
     "category": "Rating",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -7479,112 +5561,11 @@
     ]
   },
   {
-    "slug": "statuscode",
-    "name": "HTTP Status Code",
-    "description": "An HTTP status code display for building 404 and error pages.",
-    "category": "Feedback",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "shadcn/ui"
-    ],
-    "dependencies": [
-      "lucide-react"
-    ],
-    "registryDependencies": [
-      "card",
-      "input",
-      "button"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/http-status-code"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "components/spectrumui/http-status-code.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need an HTTP status code display for building 404 and error pages",
-      "form workflows",
-      "support tools"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "shadcn/ui dependencies: card, input, button",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes."
-    ],
-    "related": [
-      {
-        "slug": "alert",
-        "name": "Animated Alert",
-        "description": "An animated alert that displays notifications, warnings, and success messages."
-      },
-      {
-        "slug": "feedback",
-        "name": "Feedback Card",
-        "description": "A feedback card that collects ratings and comments with emoji reactions."
-      },
-      {
-        "slug": "notification-bell",
-        "name": "Notification Bell",
-        "description": "A bell button that swings on new notifications with a rolling unread badge."
-      },
-      {
-        "slug": "reaction-bar",
-        "name": "Reaction Bar",
-        "description": "A Slack-style emoji reaction bar with animated chips and rolling counts."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is HTTP Status Code free to use in commercial projects?",
-        "answer": "Yes. The public HTTP Status Code source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install HTTP Status Code?",
-        "answer": "Run npx shadcn@latest add @spectrumui/http-status-code. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does HTTP Status Code require Motion?",
-        "answer": "No Motion dependency was detected in the documented source or registry entry for HTTP Status Code."
-      },
-      {
-        "question": "Does HTTP Status Code use shadcn/ui or Radix UI?",
-        "answer": "HTTP Status Code uses the card, input, button shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use HTTP Status Code in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for HTTP Status Code?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "swipe-to-delete",
     "name": "Swipe to Delete",
     "description": "A swipeable list item that reveals an iOS-style delete action on drag.",
     "category": "Action",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -7739,6 +5720,7 @@
     "name": "Task Checkbox",
     "description": "A todo checkbox that celebrates completion with a confetti burst and strikethrough.",
     "category": "Form",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -7888,117 +5870,11 @@
     ]
   },
   {
-    "slug": "testimonials",
-    "name": "Testimonials",
-    "description": "A testimonials section for showcasing customer reviews and social proof.",
-    "category": "Content",
-    "technologies": [
-      "React",
-      "TypeScript",
-      "Tailwind CSS",
-      "Motion",
-      "shadcn/ui",
-      "Next.js"
-    ],
-    "dependencies": [
-      "lucide-react",
-      "framer-motion"
-    ],
-    "registryDependencies": [
-      "card"
-    ],
-    "installation": {
-      "cliCommands": [
-        "npx shadcn@latest add @spectrumui/testimonials"
-      ],
-      "dependencyCommands": [],
-      "manualPaths": [
-        "app/(docs)/docs/testimonials/testimonialsdemo.tsx",
-        "components/spectrumui/testimonials.tsx"
-      ]
-    },
-    "coverage": {
-      "installation": true,
-      "usage": false,
-      "props": false
-    },
-    "props": [],
-    "useCases": [
-      "interfaces that need a testimonials section for showcasing customer reviews and social proof",
-      "application interfaces",
-      "documentation examples"
-    ],
-    "features": [
-      "Copy-paste source that remains in your repository",
-      "TypeScript source included with the component",
-      "Tailwind CSS classes editable in the component source",
-      "Animation implemented with Motion",
-      "shadcn/ui dependencies: card",
-      "Responsive Tailwind variants present in the source"
-    ],
-    "accessibility": [
-      "No reduced-motion marker was detected; add or verify a reduced-motion path before production use.",
-      "Test focus order, keyboard operation, labels, contrast, and screen-reader output in the final application context."
-    ],
-    "customization": [
-      "Edit the Tailwind utility classes in the copied source to match your spacing, color, and typography tokens.",
-      "Edit the copied source directly for visual or structural changes.",
-      "Adjust Motion transitions in the source and keep the reduced-motion behavior aligned with the final interaction."
-    ],
-    "related": [
-      {
-        "slug": "accordion",
-        "name": "Accordion",
-        "description": "A vertically stacked set of interactive headings that each reveal a section of content."
-      },
-      {
-        "slug": "alert",
-        "name": "Animated Alert",
-        "description": "An animated alert that displays notifications, warnings, and success messages."
-      },
-      {
-        "slug": "animated-switch",
-        "name": "Animated Switch",
-        "description": "An iOS-style toggle switch with a stretchy knob you can drag or flick."
-      },
-      {
-        "slug": "animatedcard",
-        "name": "Animated Card",
-        "description": "A card that animates on hover to showcase tools, technologies, and features."
-      }
-    ],
-    "faqs": [
-      {
-        "question": "Is Testimonials free to use in commercial projects?",
-        "answer": "Yes. The public Testimonials source is available under the Apache License 2.0, including for commercial use, subject to the LICENSE terms."
-      },
-      {
-        "question": "How do I install Testimonials?",
-        "answer": "Run npx shadcn@latest add @spectrumui/testimonials. The page also exposes the source for manual installation."
-      },
-      {
-        "question": "Does Testimonials require Motion?",
-        "answer": "Yes. Motion usage was detected in the documented source or registry dependencies for Testimonials."
-      },
-      {
-        "question": "Does Testimonials use shadcn/ui or Radix UI?",
-        "answer": "Testimonials uses the card shadcn/ui dependencies."
-      },
-      {
-        "question": "Can I use Testimonials in Next.js?",
-        "answer": "The documented React source is used in this Next.js application. Keep its use client directive when copying it into the App Router. Install the detected dependencies and verify any application-specific data or image configuration."
-      },
-      {
-        "question": "What accessibility checks should I run for Testimonials?",
-        "answer": "No component-specific accessibility mechanism was detected automatically. Test keyboard operation, focus, labels, contrast, and screen-reader output before shipping."
-      }
-    ]
-  },
-  {
     "slug": "tilt-card",
     "name": "3D Tilt Card",
     "description": "A 3D card that tilts toward the pointer with parallax depth and glare.",
     "category": "Card",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",
@@ -8122,14 +5998,14 @@
         "description": "A set of pre-designed cards for login, signup, pricing, and dashboards."
       },
       {
-        "slug": "product-card",
-        "name": "Product Card",
-        "description": "A product card that displays an image, title, price, and rating."
+        "slug": "avatar-stack",
+        "name": "Avatar Stack",
+        "description": "An overlapping avatar row that fans apart on hover with springy name tooltips."
       },
       {
-        "slug": "animatedtestimonials",
-        "name": "Animated Testimonials",
-        "description": "An animated testimonials section for showcasing customer reviews and social proof."
+        "slug": "badge",
+        "name": "3D Event Badge",
+        "description": "An interactive 3D event badge rendered with Three.js and React Three Fiber."
       }
     ],
     "faqs": [
@@ -8164,6 +6040,7 @@
     "name": "Undo Pill",
     "description": "An inline undo pill with a draining countdown ring that pauses on hover.",
     "category": "Feedback",
+    "new": true,
     "technologies": [
       "React",
       "TypeScript",

--- a/lib/component-catalog.ts
+++ b/lib/component-catalog.ts
@@ -5,6 +5,8 @@ export interface ComponentCatalogItem {
   name: string;
   description: string;
   category: string;
+  /** Recently shipped — drives the "New" badge in the docs sidebar. */
+  new?: boolean;
 }
 
 export const COMPONENT_CATALOG = componentCatalog as readonly ComponentCatalogItem[];

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -72,7 +72,7 @@ export function SaveAction() {
 }
 ```
 
-## Component reference (61)
+## Component reference (44)
 
 ### Accordion
 
@@ -122,22 +122,6 @@ A drawer panel that slides in smoothly for menus, settings, and sidebars.
 - Documentation: https://ui.spectrumhq.in/docs/animateddrawer
 - Verified install command: `npx shadcn@latest add @spectrumui/animated-drawer`
 
-### Animated Testimonials
-
-An animated testimonials section for showcasing customer reviews and social proof.
-
-- Category: Review
-- Documentation: https://ui.spectrumhq.in/docs/animatedtestimonials
-- Verified install command: `npx shadcn@latest add @spectrumui/animated-testimonials`
-
-### Text Animations
-
-A collection of text effects including holographic, ink morph, and orbital reveals.
-
-- Category: Text
-- Documentation: https://ui.spectrumhq.in/docs/animatedtext
-- Verified install command: `npx shadcn@latest add @spectrumui/holographic`
-
 ### Autosize Textarea
 
 A textarea that automatically grows and shrinks to fit its content.
@@ -162,14 +146,6 @@ An interactive 3D event badge rendered with Three.js and React Three Fiber.
 - Documentation: https://ui.spectrumhq.in/docs/badge
 - Verified install command: `npx shadcn@latest add @spectrumui/event-badge-3d`
 
-### Bento Grid
-
-A bento grid layout with physics-based hover effects and scroll animations.
-
-- Category: Layout
-- Documentation: https://ui.spectrumhq.in/docs/bento-grid
-- Verified install command: `npx shadcn@latest add @spectrumui/bento-grid`
-
 ### Button
 
 A set of pre-designed buttons including gradient, outline, loading, and icon styles.
@@ -186,14 +162,6 @@ A set of pre-designed cards for login, signup, pricing, and dashboards.
 - Documentation: https://ui.spectrumhq.in/docs/card
 - Verified install command: `npx shadcn@latest add card`
 
-### Command Palette
-
-A keyboard-driven command menu for navigation, actions, and theme switching.
-
-- Category: Navigation
-- Documentation: https://ui.spectrumhq.in/docs/command-palette
-- Verified install command: `npx shadcn@latest add @spectrumui/command-palette`
-
 ### Datetime Picker
 
 A date and time picker built on shadcn/ui with no extra dependencies.
@@ -202,22 +170,6 @@ A date and time picker built on shadcn/ui with no extra dependencies.
 - Documentation: https://ui.spectrumhq.in/docs/datetime-picker
 - Verified install command: `npx shadcn@latest add @spectrumui/datetime-picker-demo`
 
-### Disclose Image
-
-An image that reveals its content behind animated sliding door panels.
-
-- Category: Media
-- Documentation: https://ui.spectrumhq.in/docs/discloseimage
-- Verified install command: `npx shadcn@latest add @spectrumui/disclose-image`
-
-### Dock Menu
-
-A macOS-style dock menu that magnifies icons on hover with tooltips.
-
-- Category: Navigation
-- Documentation: https://ui.spectrumhq.in/docs/dock
-- Verified install command: `npx shadcn@latest add @spectrumui/dock-demo`
-
 ### Dual Range Slider
 
 A slider with two draggable thumbs for selecting a range of values.
@@ -225,14 +177,6 @@ A slider with two draggable thumbs for selecting a range of values.
 - Category: Form
 - Documentation: https://ui.spectrumhq.in/docs/dual-range-slider
 - Verified install command: `npx shadcn@latest add @spectrumui/dual-range-slider-demo`
-
-### Event Calendar
-
-An interactive calendar for displaying events, appointments, and daily schedules.
-
-- Category: Calendar
-- Documentation: https://ui.spectrumhq.in/docs/eventcalendar
-- Verified install command: `npx shadcn@latest add @spectrumui/event-calendar`
 
 ### Face Rating
 
@@ -266,30 +210,6 @@ A follow button that morphs its width, fill, and label between states.
 - Documentation: https://ui.spectrumhq.in/docs/follow-button
 - Verified install command: `npx shadcn@latest add @spectrumui/follow-button`
 
-### Footer
-
-A collection of footers with wave, stacked, and particle animation styles.
-
-- Category: Layout
-- Documentation: https://ui.spectrumhq.in/docs/footer
-- Verified install command: `npx shadcn@latest add @spectrumui/footers-demo`
-
-### GitHub Profile Card
-
-A GitHub profile card generator with stats, a contribution graph, and social links.
-
-- Category: Profile
-- Documentation: https://ui.spectrumhq.in/docs/github-card
-- Verified install command: `npx shadcn@latest add @spectrumui/github-profile-card`
-
-### Heading With Anchor
-
-A heading component that adds clickable anchor links for section sharing.
-
-- Category: Text
-- Documentation: https://ui.spectrumhq.in/docs/heading-with-anchor
-- Verified install command: `npx shadcn@latest add @spectrumui/heading-with-anchor`
-
 ### Hold to Confirm
 
 A press-and-hold button that fills a progress ring before confirming destructive actions.
@@ -313,14 +233,6 @@ An infinite scroll container that loads more content using the IntersectionObser
 - Category: Data
 - Documentation: https://ui.spectrumhq.in/docs/infinite-scroll
 - Verified install command: `npx shadcn@latest add @spectrumui/infinite-scroll-demo`
-
-### Input
-
-A form input field or a component that looks like an input field.
-
-- Category: Form
-- Documentation: https://ui.spectrumhq.in/docs/input
-- Verified install command: `npx shadcn@latest add input`
 
 ### Input Model
 
@@ -394,14 +306,6 @@ A multi-step form with progress indicators for registration and checkout flows.
 - Documentation: https://ui.spectrumhq.in/docs/multistepform
 - Verified install command: `npx shadcn@latest add @spectrumui/multiple-step-form-demo`
 
-### Navbar
-
-A collection of responsive navbars with circular, tab, floating, and sidebar patterns.
-
-- Category: Navigation
-- Documentation: https://ui.spectrumhq.in/docs/navbar
-- Verified install command: `npx shadcn@latest add @spectrumui/navbar-demo`
-
 ### Notification Bell
 
 A bell button that swings on new notifications with a rolling unread badge.
@@ -417,14 +321,6 @@ A password input with an animated strength meter and requirements checklist.
 - Category: Form
 - Documentation: https://ui.spectrumhq.in/docs/password-strength
 - Verified install command: `npx shadcn@latest add @spectrumui/password-strength`
-
-### Product Card
-
-A product card that displays an image, title, price, and rating.
-
-- Category: Card
-- Documentation: https://ui.spectrumhq.in/docs/product-card
-- Verified install command: `npx shadcn@latest add @spectrumui/product-card`
 
 ### Profile Dropdown
 
@@ -458,14 +354,6 @@ A Slack-style emoji reaction bar with animated chips and rolling counts.
 - Documentation: https://ui.spectrumhq.in/docs/reaction-bar
 - Verified install command: `npx shadcn@latest add @spectrumui/reaction-bar`
 
-### Responsive Modal
-
-A dialog that centers on desktop and slides up as a sheet on mobile.
-
-- Category: Overlay
-- Documentation: https://ui.spectrumhq.in/docs/responsive-modal
-- Verified install command: `npx shadcn@latest add @spectrumui/responsive-modal`
-
 ### Scratch Card
 
 A scratch-to-reveal card that wipes away a canvas foil overlay on drag.
@@ -481,14 +369,6 @@ A share button that fans out into copy-link and custom share actions.
 - Category: Action
 - Documentation: https://ui.spectrumhq.in/docs/share-button
 - Verified install command: `npx shadcn@latest add @spectrumui/share-button`
-
-### Skeleton
-
-A loading placeholder that shimmer-animates while content is fetching.
-
-- Category: Feedback
-- Documentation: https://ui.spectrumhq.in/docs/skeleton
-- Verified install command: `npx shadcn@latest add @spectrumui/skeleton`
 
 ### Spinner
 
@@ -514,14 +394,6 @@ A status badge with icon and color variants for success, error, warning, and pen
 - Documentation: https://ui.spectrumhq.in/docs/status-badge
 - Verified install command: `npx shadcn@latest add @spectrumui/status-badge`
 
-### HTTP Status Code
-
-An HTTP status code display for building 404 and error pages.
-
-- Category: Feedback
-- Documentation: https://ui.spectrumhq.in/docs/statuscode
-- Verified install command: `npx shadcn@latest add @spectrumui/http-status-code`
-
 ### Swipe to Delete
 
 A swipeable list item that reveals an iOS-style delete action on drag.
@@ -537,14 +409,6 @@ A todo checkbox that celebrates completion with a confetti burst and strikethrou
 - Category: Form
 - Documentation: https://ui.spectrumhq.in/docs/task-checkbox
 - Verified install command: `npx shadcn@latest add @spectrumui/task-checkbox`
-
-### Testimonials
-
-A testimonials section for showcasing customer reviews and social proof.
-
-- Category: Content
-- Documentation: https://ui.spectrumhq.in/docs/testimonials
-- Verified install command: `npx shadcn@latest add @spectrumui/testimonials`
 
 ### 3D Tilt Card
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -47,7 +47,7 @@ npx shadcn@latest add @spectrumui/accordion
 
 Components can also be copied manually from their documentation source. Install only the dependencies listed for that component.
 
-## Components (61)
+## Components (44)
 
 - [Accordion](https://ui.spectrumhq.in/docs/accordion): A vertically stacked set of interactive headings that each reveal a section of content.
 - [Animated Alert](https://ui.spectrumhq.in/docs/alert): An animated alert that displays notifications, warnings, and success messages.
@@ -55,31 +55,20 @@ Components can also be copied manually from their documentation source. Install 
 - [Animated Card](https://ui.spectrumhq.in/docs/animatedcard): A card that animates on hover to showcase tools, technologies, and features.
 - [Animated SVG Chart](https://ui.spectrumhq.in/docs/animatedchart): An animated SVG chart for visualizing data on dashboards and reports.
 - [Animated Drawer](https://ui.spectrumhq.in/docs/animateddrawer): A drawer panel that slides in smoothly for menus, settings, and sidebars.
-- [Animated Testimonials](https://ui.spectrumhq.in/docs/animatedtestimonials): An animated testimonials section for showcasing customer reviews and social proof.
-- [Text Animations](https://ui.spectrumhq.in/docs/animatedtext): A collection of text effects including holographic, ink morph, and orbital reveals.
 - [Autosize Textarea](https://ui.spectrumhq.in/docs/autosize-textarea): A textarea that automatically grows and shrinks to fit its content.
 - [Avatar Stack](https://ui.spectrumhq.in/docs/avatar-stack): An overlapping avatar row that fans apart on hover with springy name tooltips.
 - [3D Event Badge](https://ui.spectrumhq.in/docs/badge): An interactive 3D event badge rendered with Three.js and React Three Fiber.
-- [Bento Grid](https://ui.spectrumhq.in/docs/bento-grid): A bento grid layout with physics-based hover effects and scroll animations.
 - [Button](https://ui.spectrumhq.in/docs/button): A set of pre-designed buttons including gradient, outline, loading, and icon styles.
 - [Card](https://ui.spectrumhq.in/docs/card): A set of pre-designed cards for login, signup, pricing, and dashboards.
-- [Command Palette](https://ui.spectrumhq.in/docs/command-palette): A keyboard-driven command menu for navigation, actions, and theme switching.
 - [Datetime Picker](https://ui.spectrumhq.in/docs/datetime-picker): A date and time picker built on shadcn/ui with no extra dependencies.
-- [Disclose Image](https://ui.spectrumhq.in/docs/discloseimage): An image that reveals its content behind animated sliding door panels.
-- [Dock Menu](https://ui.spectrumhq.in/docs/dock): A macOS-style dock menu that magnifies icons on hover with tooltips.
 - [Dual Range Slider](https://ui.spectrumhq.in/docs/dual-range-slider): A slider with two draggable thumbs for selecting a range of values.
-- [Event Calendar](https://ui.spectrumhq.in/docs/eventcalendar): An interactive calendar for displaying events, appointments, and daily schedules.
 - [Face Rating](https://ui.spectrumhq.in/docs/face-rating): A five-level rating input where an SVG face morphs between moods.
 - [Feedback Card](https://ui.spectrumhq.in/docs/feedback): A feedback card that collects ratings and comments with emoji reactions.
 - [Floating Label Input](https://ui.spectrumhq.in/docs/floating-label-input): An input whose label floats above the field when focused or filled.
 - [Follow Button](https://ui.spectrumhq.in/docs/follow-button): A follow button that morphs its width, fill, and label between states.
-- [Footer](https://ui.spectrumhq.in/docs/footer): A collection of footers with wave, stacked, and particle animation styles.
-- [GitHub Profile Card](https://ui.spectrumhq.in/docs/github-card): A GitHub profile card generator with stats, a contribution graph, and social links.
-- [Heading With Anchor](https://ui.spectrumhq.in/docs/heading-with-anchor): A heading component that adds clickable anchor links for section sharing.
 - [Hold to Confirm](https://ui.spectrumhq.in/docs/hold-to-confirm): A press-and-hold button that fills a progress ring before confirming destructive actions.
 - [Image Preview](https://ui.spectrumhq.in/docs/imagepreview): An image preview component with zoom, lightbox, and gallery support.
 - [Infinite Scroll](https://ui.spectrumhq.in/docs/infinite-scroll): An infinite scroll container that loads more content using the IntersectionObserver API.
-- [Input](https://ui.spectrumhq.in/docs/input): A form input field or a component that looks like an input field.
 - [Input Model](https://ui.spectrumhq.in/docs/input-model): A modal dialog with an input form for quick data entry.
 - [Kanban Board](https://ui.spectrumhq.in/docs/kanban): A drag-and-drop kanban board for organizing tasks into columns.
 - [Kbd Key](https://ui.spectrumhq.in/docs/kbd-key): A 3D keycap that physically depresses when the matching key is pressed.
@@ -89,25 +78,19 @@ Components can also be copied manually from their documentation source. Install 
 - [Morph Button](https://ui.spectrumhq.in/docs/morph-button): An async button that morphs between idle, loading, success, and error states.
 - [Multiple Selector](https://ui.spectrumhq.in/docs/multiple-selector): A multi-select input with async search, grouping, and creatable options.
 - [Multistep Form](https://ui.spectrumhq.in/docs/multistepform): A multi-step form with progress indicators for registration and checkout flows.
-- [Navbar](https://ui.spectrumhq.in/docs/navbar): A collection of responsive navbars with circular, tab, floating, and sidebar patterns.
 - [Notification Bell](https://ui.spectrumhq.in/docs/notification-bell): A bell button that swings on new notifications with a rolling unread badge.
 - [Password Strength](https://ui.spectrumhq.in/docs/password-strength): A password input with an animated strength meter and requirements checklist.
-- [Product Card](https://ui.spectrumhq.in/docs/product-card): A product card that displays an image, title, price, and rating.
 - [Profile Dropdown](https://ui.spectrumhq.in/docs/profile): A user profile dropdown menu with avatar, settings, and logout actions.
 - [Progress With Value](https://ui.spectrumhq.in/docs/progress-with-value): A progress bar that displays the current value.
 - [Quantity Stepper](https://ui.spectrumhq.in/docs/quantity-stepper): A quantity input with rolling digits, hold-to-repeat buttons, and boundary shake.
 - [Reaction Bar](https://ui.spectrumhq.in/docs/reaction-bar): A Slack-style emoji reaction bar with animated chips and rolling counts.
-- [Responsive Modal](https://ui.spectrumhq.in/docs/responsive-modal): A dialog that centers on desktop and slides up as a sheet on mobile.
 - [Scratch Card](https://ui.spectrumhq.in/docs/scratch-card): A scratch-to-reveal card that wipes away a canvas foil overlay on drag.
 - [Share Button](https://ui.spectrumhq.in/docs/share-button): A share button that fans out into copy-link and custom share actions.
-- [Skeleton](https://ui.spectrumhq.in/docs/skeleton): A loading placeholder that shimmer-animates while content is fetching.
 - [Spinner](https://ui.spectrumhq.in/docs/spinner): A loading spinner with multiple sizes and variants for async states.
 - [Star Rating](https://ui.spectrumhq.in/docs/star-rating): An animated star rating input with hover preview and sparkle burst effects.
 - [Status Badge](https://ui.spectrumhq.in/docs/status-badge): A status badge with icon and color variants for success, error, warning, and pending states.
-- [HTTP Status Code](https://ui.spectrumhq.in/docs/statuscode): An HTTP status code display for building 404 and error pages.
 - [Swipe to Delete](https://ui.spectrumhq.in/docs/swipe-to-delete): A swipeable list item that reveals an iOS-style delete action on drag.
 - [Task Checkbox](https://ui.spectrumhq.in/docs/task-checkbox): A todo checkbox that celebrates completion with a confetti burst and strikethrough.
-- [Testimonials](https://ui.spectrumhq.in/docs/testimonials): A testimonials section for showcasing customer reviews and social proof.
 - [3D Tilt Card](https://ui.spectrumhq.in/docs/tilt-card): A 3D card that tilts toward the pointer with parallax depth and glare.
 - [Undo Pill](https://ui.spectrumhq.in/docs/undo-pill): An inline undo pill with a draining countdown ring that pauses on hover.
 

--- a/tests/component-catalog.test.js
+++ b/tests/component-catalog.test.js
@@ -5,7 +5,30 @@ const path = require('node:path');
 const projectRoot = path.resolve(__dirname, '..');
 const docsRoot = path.join(projectRoot, 'app', '(docs)', 'docs');
 const catalog = require(path.join(projectRoot, 'content', 'component-catalog.json'));
-const nonComponentRoutes = new Set(['guides', 'installation', 'mcp']);
+// Non-component doc routes, plus the 17 components delisted from the shipped
+// catalog. Their pages still resolve (as on main) but are not part of the 44.
+const nonComponentRoutes = new Set([
+  'guides',
+  'installation',
+  'mcp',
+  'animatedtestimonials',
+  'animatedtext',
+  'bento-grid',
+  'command-palette',
+  'discloseimage',
+  'dock',
+  'eventcalendar',
+  'footer',
+  'github-card',
+  'heading-with-anchor',
+  'input',
+  'navbar',
+  'product-card',
+  'responsive-modal',
+  'skeleton',
+  'statuscode',
+  'testimonials',
+]);
 
 const routeSlugs = fs
   .readdirSync(docsRoot, { withFileTypes: true })
@@ -20,7 +43,7 @@ const routeSlugs = fs
 
 const catalogSlugs = catalog.map((component) => component.slug).sort();
 
-assert.equal(catalog.length, 61, 'The component catalog should contain 61 routes');
+assert.equal(catalog.length, 44, 'The component catalog should contain 44 routes');
 assert.equal(new Set(catalogSlugs).size, catalog.length, 'Component slugs must be unique');
 assert.equal(
   new Set(catalog.map((component) => component.name)).size,

--- a/tests/component-docs.test.js
+++ b/tests/component-docs.test.js
@@ -7,7 +7,7 @@ const catalog = require(path.join(projectRoot, 'content', 'component-catalog.jso
 const componentDocs = require(path.join(projectRoot, 'content', 'component-docs.json'));
 const docsRoot = path.join(projectRoot, 'app', '(docs)', 'docs');
 
-assert.equal(componentDocs.length, 61, 'Every component route needs generated documentation');
+assert.equal(componentDocs.length, 44, 'Every component route needs generated documentation');
 assert.deepEqual(
   componentDocs.map((component) => component.slug).sort(),
   catalog.map((component) => component.slug).sort(),

--- a/tests/metadata.test.js
+++ b/tests/metadata.test.js
@@ -146,7 +146,7 @@ const publicDescriptions = [
   ...topicHubDescriptions,
 ];
 
-assert.equal(componentTitles.length, 61);
+assert.equal(componentTitles.length, 44);
 assert.ok(componentTitles.every((title) => title.length <= 60));
 assert.ok(componentDescriptions.every((description) => description.length <= 155));
 assert.ok(blogTitles.every((title) => title.length <= 60));


### PR DESCRIPTION
## Summary
PR #124 (just merged) centralized the component catalog but accidentally re-added 17 components that had been intentionally removed from the live site. This restores the correct 44-component catalog and brings back the sidebar "New" badges that were lost in that centralization.

- `content/component-catalog.json`: 61 → 44 (drops `animatedtestimonials`, `animatedtext`, `bento-grid`, `command-palette`, `discloseimage`, `dock`, `eventcalendar`, `footer`, `github-card`, `heading-with-anchor`, `input`, `navbar`, `product-card`, `responsive-modal`, `skeleton`, `statuscode`, `testimonials`)
- Added `new?: boolean` to the catalog type + flagged the 15 recently-shipped components (3D Tilt Card, Animated Drawer, Avatar Stack, Face Rating, Follow Button, Hold to Confirm, Like Button, Notification Bell, Password Strength, Reaction Bar, Scratch Card, Star Rating, Swipe to Delete, Task Checkbox, Undo Pill) — threaded through to the docs sidebar's existing "New" badge render
- Regenerated `component-docs.json` (44 routes, 264 FAQs) and `llms.txt` / `llms-full.txt` (`Components (44)`)
- The 17 delisted pages still resolve on disk (unlinked, same as before) but are excluded from the sitemap and the catalog/route-match test
- Updated test assertions (catalog 44, component-docs 44, metadata 107 pairs, structured-data 44 schemas, hubs 44-of-44)

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm test` — all 6 suites pass
- [x] `npm run check:llms` — current
- [x] `next build` — 166 pages
- [ ] Spot-check `/docs` sidebar shows 44 components with "New" badges on the 15 flagged ones, and none of the 17 removed slugs appear in nav/footer/sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the catalog to the correct 44 shipped components and brings back "New" badges in the docs sidebar. Removes 17 delisted components from the catalog, sitemap, and route tests while keeping their pages resolvable.

- **Bug Fixes**
  - Reduced `content/component-catalog.json` from 61 to 44; removed 17 delisted slugs; added `new?: boolean` and flagged 15 recent components.
  - Restored "New" badges by threading `new` through `documentation.constant.ts`.
  - Excluded delisted routes in `app/sitemap.ts`.
  - Regenerated `component-docs.json` and `public/llms*.txt` for 44 components.
  - Updated tests to assert 44 components and align route matching/metadata.

<sup>Written for commit cb96cb9ecd326e3d5f6d382d7058436905225e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arihantcodes/spectrum-ui/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

