### PR TITLE
feat(design): scaffold the /design inspiration gallery — schema, taxonomy, bordered shell, feed, /go redirects

### DIFF
--- a/app/(design)/design/c/[category]/page.tsx
+++ b/app/(design)/design/c/[category]/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
+
+import type { DesignSort } from "@/lib/design/types";
 
 import { FeedGrid } from "@/components/design/feed-grid";
 import { SectionHeader } from "@/components/design/section-header";
@@ -49,7 +52,10 @@ export default async function DesignCategoryPage({ params }: PageProps) {
   const category = findDesignCategory("feed", slug);
   if (!category) notFound();
 
-  const { items } = await getFeed({ section: "feed", category: slug });
+  const rawSort = (await cookies()).get("design_sort")?.value;
+  const sort: DesignSort =
+    rawSort === "popular" || rawSort === "staff" ? rawSort : "recent";
+  const { items } = await getFeed({ section: "feed", category: slug, sort });
 
   return (
     <>
@@ -91,28 +97,31 @@ export default async function DesignCategoryPage({ params }: PageProps) {
         count={items.length}
         heading={`${category.name} Design Inspiration`}
         subheading={`Curated ${category.name.toLowerCase()} work, attributed to its creators.`}
+        sort={sort}
       />
 
-      {/* The indexable body of the page. Renders whether or not items exist,
-          which is what lets these routes rank before the gallery fills up. */}
-      <div className="mb-8 max-w-[68ch]">
-        <h2 className="sr-only">About {category.name} design inspiration</h2>
-        <p className="text-[13px] leading-[1.75] text-muted-foreground">
-          {category.intro}
-        </p>
-      </div>
-
-      {items.length > 0 ? (
-        <FeedGrid
-          items={items}
-          layout={section.layout}
-          aspectRatio={section.aspectRatio}
-        />
-      ) : (
-        <div className="rounded-lg border border-dashed px-6 py-12 text-center text-[13px] text-muted-foreground">
-          No {category.name.toLowerCase()} items published yet.
+      <div className="px-4 py-5 sm:px-6">
+        {/* The indexable body of the page. Renders whether or not items exist,
+            which is what lets these routes rank before the gallery fills up. */}
+        <div className="mb-6 max-w-[68ch]">
+          <h2 className="sr-only">About {category.name} design inspiration</h2>
+          <p className="text-[13px] leading-[1.75] text-muted-foreground">
+            {category.intro}
+          </p>
         </div>
-      )}
+
+        {items.length > 0 ? (
+          <FeedGrid
+            items={items}
+            layout={section.layout}
+            aspectRatio={section.aspectRatio}
+          />
+        ) : (
+          <div className="rounded-lg border border-dashed px-6 py-12 text-center text-[13px] text-muted-foreground">
+            No {category.name.toLowerCase()} items published yet.
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/app/(design)/design/c/[category]/page.tsx
+++ b/app/(design)/design/c/[category]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { FeedGrid } from "@/components/design/feed-grid";
+import { SectionHeader } from "@/components/design/section-header";
+import {
+  DESIGN_SECTION_MAP,
+  findDesignCategory,
+} from "@/content/design-taxonomy";
+import { getFeed } from "@/lib/design/queries";
+import { siteConfig } from "@/config/site";
+import { JsonLd } from "@/components/seo/json-ld";
+
+const section = DESIGN_SECTION_MAP.get("feed")!;
+
+interface PageProps {
+  params: Promise<{ category: string }>;
+}
+
+/** All category pages are statically known — they do not depend on the DB. */
+export function generateStaticParams() {
+  return section.categories.map((c) => ({ category: c.slug }));
+}
+
+export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { category: slug } = await params;
+  const category = findDesignCategory("feed", slug);
+  if (!category) return {};
+
+  const url = `${siteConfig.url}/design/c/${slug}`;
+  const title = `${category.name} Design Inspiration`;
+  // First sentence of the intro doubles as the meta description.
+  const description = `${category.intro.split(". ")[0]}.`;
+
+  return {
+    title: { absolute: `${title} | Spectrum UI` },
+    description,
+    alternates: { canonical: url },
+    openGraph: { title, description, url, type: "website" },
+  };
+}
+
+export default async function DesignCategoryPage({ params }: PageProps) {
+  const { category: slug } = await params;
+  const category = findDesignCategory("feed", slug);
+  if (!category) notFound();
+
+  const { items } = await getFeed({ section: "feed", category: slug });
+
+  return (
+    <>
+      <JsonLd
+        id={`design-category-${slug}`}
+        data={{
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  name: "Design",
+                  item: `${siteConfig.url}/design`,
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  name: category.name,
+                  item: `${siteConfig.url}/design/c/${slug}`,
+                },
+              ],
+            },
+            {
+              "@type": "ItemList",
+              name: `${category.name} Design Inspiration`,
+              url: `${siteConfig.url}/design/c/${slug}`,
+              numberOfItems: items.length,
+            },
+          ],
+        }}
+      />
+
+      <SectionHeader
+        section={section}
+        activeCategory={slug}
+        count={items.length}
+        heading={`${category.name} Design Inspiration`}
+        subheading={`Curated ${category.name.toLowerCase()} work, attributed to its creators.`}
+      />
+
+      {/* The indexable body of the page. Renders whether or not items exist,
+          which is what lets these routes rank before the gallery fills up. */}
+      <div className="mb-8 max-w-[68ch]">
+        <h2 className="sr-only">About {category.name} design inspiration</h2>
+        <p className="text-[13px] leading-[1.75] text-muted-foreground">
+          {category.intro}
+        </p>
+      </div>
+
+      {items.length > 0 ? (
+        <FeedGrid
+          items={items}
+          layout={section.layout}
+          aspectRatio={section.aspectRatio}
+        />
+      ) : (
+        <div className="rounded-lg border border-dashed px-6 py-12 text-center text-[13px] text-muted-foreground">
+          No {category.name.toLowerCase()} items published yet.
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(design)/design/layout.tsx
+++ b/app/(design)/design/layout.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { DesignSidebar } from "@/components/design/design-sidebar";
+import { getSectionCounts } from "@/lib/design/queries";
+import { siteConfig } from "@/config/site";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Design Inspiration",
+    template: "%s | Spectrum Design",
+  },
+  description:
+    "A curated gallery of interface, web, product and motion design — each item attributed to its creator and tagged with the Spectrum UI components that could rebuild it.",
+  alternates: { canonical: `${siteConfig.url}/design` },
+};
+
+/**
+ * Three-column shell.
+ *
+ * The global site header is deliberately kept. Funnelling gallery traffic into
+ * the component library is the third business goal, and removing the nav that
+ * points at /docs would work directly against it. The rail therefore sits under
+ * the 3.5rem sticky header rather than owning the full viewport, matching the
+ * offset convention already used by /docs.
+ */
+export default async function DesignLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const counts = await getSectionCounts();
+  const year = new Date().getFullYear();
+
+  return (
+    <div className="mx-auto w-full max-w-[1680px] px-4">
+      <div className="lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-8 xl:grid-cols-[220px_minmax(0,1fr)_256px]">
+        {/* Left rail */}
+        <aside className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 lg:block">
+          <div className="no-scrollbar flex h-full flex-col overflow-y-auto py-6">
+            <DesignSidebar counts={counts} />
+            <div className="mt-auto space-y-3 pt-6 text-[11px] text-muted-foreground">
+              <Link
+                href="/docs"
+                className="block rounded-md border border-dashed px-3 py-2.5 leading-relaxed transition-colors hover:border-solid hover:text-foreground"
+              >
+                <span className="font-medium text-foreground">
+                  Built with Spectrum UI
+                </span>
+                <br />
+                Every item is tagged with the components that could rebuild it.
+              </Link>
+              <p>© {year} Spectrum UI</p>
+            </div>
+          </div>
+        </aside>
+
+        {/* Center */}
+        <main className="min-w-0 py-6">{children}</main>
+
+        {/* Right rail — jobs + sponsored units land here in a later slice. */}
+        <aside className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 xl:block">
+          <div className="no-scrollbar h-full overflow-y-auto py-6" />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/app/(design)/design/layout.tsx
+++ b/app/(design)/design/layout.tsx
@@ -16,13 +16,15 @@ export const metadata: Metadata = {
 };
 
 /**
- * Three-column shell.
+ * Bordered three-column shell, recent.design mechanics in this site's visual
+ * language: `container-wrapper` draws the dashed hairline rules at the
+ * container edges once the viewport exceeds it (the site-wide convention the
+ * header and docs already use), and the rails are separated from the feed by
+ * the same dashed border rather than whitespace.
  *
- * The global site header is deliberately kept. Funnelling gallery traffic into
- * the component library is the third business goal, and removing the nav that
- * points at /docs would work directly against it. The rail therefore sits under
- * the 3.5rem sticky header rather than owning the full viewport, matching the
- * offset convention already used by /docs.
+ * The global site header is deliberately kept — funnelling gallery traffic
+ * into the component library is a core goal, so the nav that points at /docs
+ * stays. Rails pin below its 3.5rem height.
  */
 export default async function DesignLayout({
   children,
@@ -33,34 +35,37 @@ export default async function DesignLayout({
   const year = new Date().getFullYear();
 
   return (
-    <div className="mx-auto w-full max-w-[1680px] px-4">
-      <div className="lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-8 xl:grid-cols-[220px_minmax(0,1fr)_256px]">
+    <div className="container-wrapper flex-1">
+      <div className="lg:grid lg:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-[220px_minmax(0,1fr)_256px]">
         {/* Left rail */}
-        <aside className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 lg:block">
-          <div className="no-scrollbar flex h-full flex-col overflow-y-auto py-6">
+        <aside className="border-grid sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 border-r lg:block">
+          <div className="no-scrollbar flex h-full flex-col overflow-y-auto px-4 py-6">
             <DesignSidebar counts={counts} />
-            <div className="mt-auto space-y-3 pt-6 text-[11px] text-muted-foreground">
-              <Link
-                href="/docs"
-                className="block rounded-md border border-dashed px-3 py-2.5 leading-relaxed transition-colors hover:border-solid hover:text-foreground"
-              >
-                <span className="font-medium text-foreground">
-                  Built with Spectrum UI
-                </span>
-                <br />
-                Every item is tagged with the components that could rebuild it.
-              </Link>
+            <div className="mt-auto pt-6 text-[11px] text-muted-foreground">
               <p>© {year} Spectrum UI</p>
             </div>
           </div>
         </aside>
 
-        {/* Center */}
-        <main className="min-w-0 py-6">{children}</main>
+        {/* Center — pages render their own header row + sticky filter rail. */}
+        <main className="min-w-0">{children}</main>
 
-        {/* Right rail — jobs + sponsored units land here in a later slice. */}
-        <aside className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 xl:block">
-          <div className="no-scrollbar h-full overflow-y-auto py-6" />
+        {/* Right rail — job listings and the sponsored media unit land here.
+            Until then it carries the house unit only. */}
+        <aside className="border-grid sticky top-14 hidden h-[calc(100dvh-3.5rem)] shrink-0 border-l xl:block">
+          <div className="no-scrollbar h-full overflow-y-auto px-4 py-6">
+            <Link
+              href="/docs"
+              className="block rounded-lg border border-dashed px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground transition-colors hover:border-solid hover:text-foreground"
+            >
+              <span className="font-medium text-foreground">
+                Built with Spectrum UI
+              </span>
+              <br />
+              Every item is tagged with the components that could rebuild it —
+              browse the library.
+            </Link>
+          </div>
         </aside>
       </div>
     </div>

--- a/app/(design)/design/page.tsx
+++ b/app/(design)/design/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+
+import { FeedGrid } from "@/components/design/feed-grid";
+import { SectionHeader } from "@/components/design/section-header";
+import { DESIGN_SECTION_MAP } from "@/content/design-taxonomy";
+import { getFeed } from "@/lib/design/queries";
+import { siteConfig } from "@/config/site";
+import { JsonLd } from "@/components/seo/json-ld";
+
+const section = DESIGN_SECTION_MAP.get("feed")!;
+
+export const metadata: Metadata = {
+  title: { absolute: "Design Inspiration — Interface, Web & Motion | Spectrum UI" },
+  description:
+    "A curated gallery of interface, web, product and motion design. Every item is attributed to its creator and tagged with the Spectrum UI components that could rebuild it.",
+  alternates: { canonical: `${siteConfig.url}/design` },
+  openGraph: {
+    title: "Design Inspiration — Interface, Web & Motion",
+    description:
+      "A curated gallery of interface, web, product and motion design, updated daily.",
+    url: `${siteConfig.url}/design`,
+    type: "website",
+  },
+};
+
+// The gallery is curated throughout the day; revalidate rather than rebuild.
+export const revalidate = 300;
+
+export default async function DesignFeedPage() {
+  const { items, unavailable } = await getFeed({ section: "feed" });
+
+  return (
+    <>
+      <JsonLd
+        id="design-feed-itemlist"
+        data={{
+          "@context": "https://schema.org",
+          "@type": "ItemList",
+          name: "Design Inspiration",
+          description: section.description,
+          url: `${siteConfig.url}/design`,
+          numberOfItems: items.length,
+          itemListElement: items.slice(0, 24).map((item, i) => ({
+            "@type": "ListItem",
+            position: i + 1,
+            url: `${siteConfig.url}/design/i/${item.slug}`,
+            name: item.title,
+          })),
+        }}
+      />
+
+      <SectionHeader section={section} count={items.length} />
+
+      {items.length > 0 ? (
+        <FeedGrid
+          items={items}
+          layout={section.layout}
+          aspectRatio={section.aspectRatio}
+        />
+      ) : (
+        <EmptyState unavailable={unavailable} />
+      )}
+    </>
+  );
+}
+
+function EmptyState({ unavailable }: { unavailable: boolean }) {
+  return (
+    <div className="rounded-lg border border-dashed px-6 py-16 text-center">
+      <p className="text-[13px] font-medium">
+        {unavailable ? "Gallery not provisioned yet" : "Nothing published yet"}
+      </p>
+      <p className="mx-auto mt-2 max-w-[46ch] text-[13px] leading-relaxed text-muted-foreground">
+        {unavailable ? (
+          <>
+            Run <code className="font-mono text-[12px]">design-schema.sql</code>{" "}
+            in Supabase to create the gallery tables. Every route, including the
+            category pages and their intro copy, renders without it — only the
+            items are missing.
+          </>
+        ) : (
+          <>
+            The taxonomy and routes are live. Publish items from the admin queue
+            and they will appear here.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/app/(design)/design/page.tsx
+++ b/app/(design)/design/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 
 import { FeedGrid } from "@/components/design/feed-grid";
 import { SectionHeader } from "@/components/design/section-header";
 import { DESIGN_SECTION_MAP } from "@/content/design-taxonomy";
 import { getFeed } from "@/lib/design/queries";
+import type { DesignSort } from "@/lib/design/types";
 import { siteConfig } from "@/config/site";
 import { JsonLd } from "@/components/seo/json-ld";
 
@@ -26,8 +28,25 @@ export const metadata: Metadata = {
 // The gallery is curated throughout the day; revalidate rather than rebuild.
 export const revalidate = 300;
 
+/** Sort lives in a cookie so it survives navigation without minting URLs. */
+async function readSort(): Promise<DesignSort> {
+  const raw = (await cookies()).get("design_sort")?.value;
+  return raw === "popular" || raw === "staff" ? raw : "recent";
+}
+
 export default async function DesignFeedPage() {
-  const { items, unavailable } = await getFeed({ section: "feed" });
+  const sort = await readSort();
+  const { items, unavailable } = await getFeed({ section: "feed", sort });
+  const updatedAt =
+    items.length > 0
+      ? items.reduce<string | null>(
+          (latest, it) =>
+            it.publishedAt && (!latest || it.publishedAt > latest)
+              ? it.publishedAt
+              : latest,
+          null,
+        )
+      : null;
 
   return (
     <>
@@ -49,17 +68,24 @@ export default async function DesignFeedPage() {
         }}
       />
 
-      <SectionHeader section={section} count={items.length} />
+      <SectionHeader
+        section={section}
+        count={items.length}
+        updatedAt={updatedAt}
+        sort={sort}
+      />
 
-      {items.length > 0 ? (
-        <FeedGrid
-          items={items}
-          layout={section.layout}
-          aspectRatio={section.aspectRatio}
-        />
-      ) : (
-        <EmptyState unavailable={unavailable} />
-      )}
+      <div className="px-4 py-5 sm:px-6">
+        {items.length > 0 ? (
+          <FeedGrid
+            items={items}
+            layout={section.layout}
+            aspectRatio={section.aspectRatio}
+          />
+        ) : (
+          <EmptyState unavailable={unavailable} />
+        )}
+      </div>
     </>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -483,6 +483,11 @@
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
+    /* Spectrum Design — tint held behind gallery media while it loads. Sitting
+       just off the page background stops a grid of loading cards reading as
+       holes in the layout. Paired with the stored aspect ratio, this is what
+       makes the feed load without any visible reflow. */
+    --design-media-placeholder: hsl(0 0% 96%);
     --chart-1: 199 89% 48%;
     --chart-2: 209 75% 64%;
     --chart-3: 197 37% 24%;
@@ -507,6 +512,7 @@
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
+    --design-media-placeholder: hsl(0 0% 9%);
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 3.9%;

--- a/app/go/[code]/route.ts
+++ b/app/go/[code]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { siteConfig } from "@/config/site";
+
+/**
+ * Tracked outbound redirect: /go/[code]?s=<surface>&p=<position>
+ *
+ * `code` resolves in two ways, checked in order:
+ *   1. a row in design_outbound_links (sponsors, tools, jobs — paid links), or
+ *   2. a design_items.short_id, which redirects to that item's source_url.
+ *
+ * The second form is why feed cards can link straight to /go/<short_id> without
+ * us pre-creating a link row for every gallery item.
+ *
+ * Always 302, never 301: these targets change and must not be cached forever by
+ * browsers. Click counting is fire-and-forget — a failed increment must never
+ * cost the user their navigation.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const { code } = await params;
+  const home = new URL("/design", siteConfig.url);
+
+  if (!code || code.length > 64) {
+    return NextResponse.redirect(home, 302);
+  }
+
+  let target: string | null = null;
+  let paid = false;
+
+  try {
+    const { data: link } = await supabaseAdmin
+      .from("design_outbound_links")
+      .select("id, target, kind, clicks")
+      .eq("code", code)
+      .maybeSingle();
+
+    if (link?.target) {
+      target = link.target;
+      paid = link.kind === "sponsor" || link.kind === "tool" || link.kind === "job";
+      void supabaseAdmin
+        .from("design_outbound_links")
+        .update({ clicks: (link.clicks ?? 0) + 1 })
+        .eq("id", link.id)
+        .then(undefined, () => {});
+    } else {
+      const { data: item } = await supabaseAdmin
+        .from("design_items")
+        .select("id, source_url, outbound_clicks")
+        .eq("short_id", code)
+        .eq("status", "published")
+        .maybeSingle();
+
+      if (item?.source_url) {
+        target = item.source_url;
+        void supabaseAdmin
+          .from("design_items")
+          .update({ outbound_clicks: (item.outbound_clicks ?? 0) + 1 })
+          .eq("id", item.id)
+          .then(undefined, () => {});
+      }
+    }
+  } catch {
+    // Fall through to the safe redirect below.
+  }
+
+  if (!target) return NextResponse.redirect(home, 302);
+
+  // Only http(s) may be redirected to — never let a stored value become a
+  // javascript: or data: navigation.
+  let destination: URL;
+  try {
+    destination = new URL(target);
+    if (destination.protocol !== "https:" && destination.protocol !== "http:") {
+      return NextResponse.redirect(home, 302);
+    }
+  } catch {
+    return NextResponse.redirect(home, 302);
+  }
+
+  const response = NextResponse.redirect(destination, 302);
+  // Paid placements must not pass link equity.
+  response.headers.set(
+    "X-Robots-Tag",
+    paid ? "noindex, nofollow" : "noindex, follow",
+  );
+  return response;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,6 +38,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { LinkPrefetch } from "@/components/seo/link-prefetch";
 import { TalkToUs } from "@/components/talk-to-us";
 import { JsonLd } from "@/components/seo/json-ld";
+import { AdSenseScript } from "@/components/seo/adsense-script";
 import { generateSiteStructuredData } from "@/lib/site-structured-data";
 
 inject();
@@ -156,12 +157,7 @@ gtag('config', 'G-K7ZP6JB4MG');
           id="spectrum-ui-structured-data"
           data={generateSiteStructuredData()}
         />
-        <Script
-          id="adsense"
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8119622964025792"
-          strategy="lazyOnload"
-          crossOrigin="anonymous"
-        />
+        <AdSenseScript />
       </head>
       <body className="font-regular" suppressHydrationWarning>
         <Providers>

--- a/components/design/card-video.tsx
+++ b/components/design/card-video.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Feed video per spec §7: muted, looping, inline, metadata-only preload.
+ * Plays only while ≥50% in the viewport, pauses when scrolled away or the tab
+ * is hidden, and never autoplays under prefers-reduced-motion. GIF submissions
+ * are transcoded to mp4 at ingest, so this is also the "GIF" path — a real
+ * GIF would cost megabytes and decode on the main thread.
+ */
+export function CardVideo({
+  src,
+  webm,
+  poster,
+  className,
+}: {
+  src: string;
+  webm?: string | null;
+  poster?: string | null;
+  className?: string;
+}) {
+  const ref = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const video = ref.current;
+    if (!video) return;
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let inView = false;
+
+    const sync = () => {
+      if (inView && !document.hidden && !reduced.matches) {
+        video.play().catch(() => {});
+      } else {
+        video.pause();
+      }
+    };
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting;
+        sync();
+      },
+      { threshold: 0.5 },
+    );
+    io.observe(video);
+
+    document.addEventListener("visibilitychange", sync);
+    reduced.addEventListener("change", sync);
+    return () => {
+      io.disconnect();
+      document.removeEventListener("visibilitychange", sync);
+      reduced.removeEventListener("change", sync);
+    };
+  }, []);
+
+  return (
+    <video
+      ref={ref}
+      muted
+      loop
+      playsInline
+      preload="metadata"
+      poster={poster ?? undefined}
+      className={className}
+    >
+      {webm && <source src={webm} type="video/webm" />}
+      <source src={src} type="video/mp4" />
+    </video>
+  );
+}

--- a/components/design/design-sidebar.tsx
+++ b/components/design/design-sidebar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+import { DESIGN_SECTIONS } from "@/content/design-taxonomy";
+
+export function DesignSidebar({
+  counts = {},
+}: {
+  counts?: Record<string, number>;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Design sections" className="flex h-full flex-col">
+      <ul className="space-y-0.5">
+        {DESIGN_SECTIONS.map((section) => {
+          // /design must only match exactly, or it lights up on every subroute.
+          const active =
+            section.path === "/design"
+              ? pathname === "/design" || pathname.startsWith("/design/c/")
+              : pathname.startsWith(section.path);
+          const count = counts[section.slug];
+
+          return (
+            <li key={section.slug}>
+              <Link
+                href={section.path}
+                className={cn(
+                  "flex items-center justify-between rounded-md px-2 py-1.5 text-[13px] transition-colors",
+                  active
+                    ? "bg-accent font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <span>{section.name}</span>
+                <span className="flex items-center gap-1.5">
+                  {typeof count === "number" && count > 0 && (
+                    <span className="text-[11px] tabular-nums text-muted-foreground/70">
+                      {count}
+                    </span>
+                  )}
+                  {active && (
+                    <span
+                      aria-hidden
+                      className="size-1.5 rounded-full bg-foreground"
+                    />
+                  )}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+    </nav>
+  );
+}

--- a/components/design/design-sidebar.tsx
+++ b/components/design/design-sidebar.tsx
@@ -6,6 +6,10 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { DESIGN_SECTIONS } from "@/content/design-taxonomy";
 
+/**
+ * Section nav, recent.design mechanics: plain text rows, the active section
+ * carries a small filled dot on the right, counts sit quietly beside it.
+ */
 export function DesignSidebar({
   counts = {},
 }: {
@@ -14,8 +18,8 @@ export function DesignSidebar({
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Design sections" className="flex h-full flex-col">
-      <ul className="space-y-0.5">
+    <nav aria-label="Design sections">
+      <ul className="space-y-1">
         {DESIGN_SECTIONS.map((section) => {
           // /design must only match exactly, or it lights up on every subroute.
           const active =
@@ -29,32 +33,31 @@ export function DesignSidebar({
               <Link
                 href={section.path}
                 className={cn(
-                  "flex items-center justify-between rounded-md px-2 py-1.5 text-[13px] transition-colors",
+                  "flex items-center justify-between py-1 text-[13px] transition-colors",
                   active
-                    ? "bg-accent font-medium text-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                <span>{section.name}</span>
-                <span className="flex items-center gap-1.5">
+                <span className="flex items-baseline gap-2">
+                  {section.name}
                   {typeof count === "number" && count > 0 && (
-                    <span className="text-[11px] tabular-nums text-muted-foreground/70">
+                    <span className="text-[11px] tabular-nums text-muted-foreground/60">
                       {count}
                     </span>
                   )}
-                  {active && (
-                    <span
-                      aria-hidden
-                      className="size-1.5 rounded-full bg-foreground"
-                    />
-                  )}
                 </span>
+                {active && (
+                  <span
+                    aria-hidden
+                    className="size-1.5 rounded-full bg-foreground"
+                  />
+                )}
               </Link>
             </li>
           );
         })}
       </ul>
-
     </nav>
   );
 }

--- a/components/design/feed-grid.tsx
+++ b/components/design/feed-grid.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/lib/utils";
+import type { DesignItem } from "@/lib/design/types";
+import type { DesignLayout } from "@/content/design-taxonomy";
+import { MediaCard } from "./media-card";
+
+/**
+ * CSS multi-column masonry rather than a JS masonry library.
+ *
+ * Columns cost nothing at runtime: no measurement pass, no layout thrash, and
+ * it renders correctly from the server on first paint. The tradeoff is that
+ * reading order runs down each column rather than across, which is acceptable
+ * for a browse surface where order is "recency", not meaning.
+ *
+ * Uniform sections (websites, OG images, screenshots) use a real grid instead,
+ * because a fixed aspect ratio makes columns pointless.
+ */
+export function FeedGrid({
+  items,
+  layout,
+  aspectRatio,
+  /** Number of leading cards to mark priority — the first visible row. */
+  priorityCount = 8,
+}: {
+  items: DesignItem[];
+  layout: DesignLayout;
+  aspectRatio: number | null;
+  priorityCount?: number;
+}) {
+  if (layout === "icons") {
+    return (
+      <div className="grid grid-cols-3 gap-4 sm:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8">
+        {items.map((item, i) => (
+          <MediaCard
+            key={item.id}
+            item={item}
+            aspectRatio={1}
+            priority={i < priorityCount}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (layout === "uniform") {
+    return (
+      <div
+        className={cn(
+          "grid gap-4",
+          aspectRatio && aspectRatio > 1.8
+            ? "grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
+            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+        )}
+      >
+        {items.map((item, i) => (
+          <MediaCard
+            key={item.id}
+            item={item}
+            aspectRatio={aspectRatio}
+            priority={i < priorityCount}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="columns-1 gap-4 sm:columns-2 lg:columns-3 xl:columns-4 2xl:columns-5">
+      {items.map((item, i) => (
+        <MediaCard key={item.id} item={item} priority={i < priorityCount} />
+      ))}
+    </div>
+  );
+}

--- a/components/design/media-card.tsx
+++ b/components/design/media-card.tsx
@@ -1,0 +1,137 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { DesignItem } from "@/lib/design/types";
+
+/** Column widths the feed actually renders at, so `sizes` matches reality. */
+const CARD_SIZES =
+  "(min-width: 1536px) 20vw, (min-width: 1280px) 25vw, (min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw";
+
+function pickSrc(srcSet: Record<string, string>): string | null {
+  if (!srcSet) return null;
+  const widths = Object.keys(srcSet)
+    .map(Number)
+    .filter((n) => !Number.isNaN(n))
+    .sort((a, b) => a - b);
+  if (widths.length === 0) return null;
+  // 1080 is the sweet spot for a masonry column on a 2x display.
+  const chosen = widths.find((w) => w >= 1080) ?? widths[widths.length - 1];
+  return srcSet[String(chosen)] ?? null;
+}
+
+export function MediaCard({
+  item,
+  priority = false,
+  aspectRatio,
+}: {
+  item: DesignItem;
+  /** First row only — these are the LCP candidates. */
+  priority?: boolean;
+  /** Forced ratio for uniform-grid sections; masonry passes undefined. */
+  aspectRatio?: number | null;
+}) {
+  const cover = item.media[0];
+  if (!cover) return null;
+
+  const src = pickSrc(cover.srcSet);
+  const ratio = aspectRatio ?? cover.width / cover.height;
+
+  return (
+    <article
+      className={cn(
+        "group relative mb-3 break-inside-avoid",
+        // Reserve the exact box before the image loads. This is what keeps CLS ~0.
+        "overflow-hidden rounded-lg",
+      )}
+      style={{ aspectRatio: aspectRatio ? String(aspectRatio) : undefined }}
+    >
+      <Link
+        href={`/design/i/${item.slug}`}
+        className="block focus-visible:outline-hidden"
+        aria-label={`${item.title} by ${item.authorName}`}
+      >
+        <div
+          className="relative w-full overflow-hidden rounded-lg bg-[var(--design-media-placeholder)]"
+          style={{ aspectRatio: String(ratio) }}
+        >
+          {src ? (
+            <Image
+              src={src}
+              alt={item.title}
+              fill
+              sizes={CARD_SIZES}
+              priority={priority}
+              loading={priority ? undefined : "lazy"}
+              decoding="async"
+              className="object-cover transition-transform duration-300 ease-[cubic-bezier(0.2,0,0,1)] group-hover:scale-[1.015]"
+              style={
+                cover.dominantColor
+                  ? { backgroundColor: cover.dominantColor }
+                  : undefined
+              }
+            />
+          ) : (
+            <div className="absolute inset-0 grid place-items-center text-xs text-muted-foreground">
+              {item.title}
+            </div>
+          )}
+
+          {/* Inset hairline so light images still read as cards. */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-lg ring-1 ring-inset ring-black/[0.06] dark:ring-white/[0.08]"
+          />
+
+          {/* Slide count */}
+          {item.media.length > 1 && (
+            <span className="pointer-events-none absolute right-2 top-2 rounded-full bg-black/60 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-white backdrop-blur-xs">
+              {item.media.length}
+            </span>
+          )}
+        </div>
+      </Link>
+
+      {/* Overlays fade in together on hover or keyboard focus. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between p-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        {item.authorUrl ? (
+          <a
+            href={item.authorUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-black/60 py-1 pl-1 pr-2.5 text-[11px] text-white backdrop-blur-xs focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
+          >
+            {item.authorAvatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={item.authorAvatar}
+                alt=""
+                width={18}
+                height={18}
+                className="size-[18px] rounded-full object-cover"
+              />
+            ) : (
+              <span className="grid size-[18px] place-items-center rounded-full bg-white/20 text-[9px]">
+                {item.authorName.charAt(0).toUpperCase()}
+              </span>
+            )}
+            <span className="max-w-[12ch] truncate">{item.authorName}</span>
+          </a>
+        ) : (
+          <span />
+        )}
+
+        <a
+          href={`/go/${item.shortId}?s=feed`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Open the original post for ${item.title}`}
+          className="pointer-events-auto grid size-7 place-items-center rounded-full bg-black/60 text-white backdrop-blur-xs transition-colors hover:bg-black/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
+        >
+          <ArrowUpRight className="size-3.5" />
+        </a>
+      </div>
+    </article>
+  );
+}

--- a/components/design/media-card.tsx
+++ b/components/design/media-card.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { DesignItem } from "@/lib/design/types";
+import { CardVideo } from "./card-video";
 
 /** Column widths the feed actually renders at, so `sizes` matches reality. */
 const CARD_SIZES =
@@ -56,7 +57,14 @@ export function MediaCard({
           className="relative w-full overflow-hidden rounded-lg bg-[var(--design-media-placeholder)]"
           style={{ aspectRatio: String(ratio) }}
         >
-          {src ? (
+          {cover.kind === "video" && cover.videoUrl ? (
+            <CardVideo
+              src={cover.videoUrl}
+              webm={cover.videoWebm}
+              poster={cover.posterUrl ?? src}
+              className="absolute inset-0 size-full object-cover"
+            />
+          ) : src ? (
             <Image
               src={src}
               alt={item.title}
@@ -93,8 +101,10 @@ export function MediaCard({
         </div>
       </Link>
 
-      {/* Overlays fade in together on hover or keyboard focus. */}
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between p-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+      {/* Attribution stays visible at rest (recent.design mechanics — credit is
+          part of the card, not a reward for hovering); the outbound arrow still
+          fades in on hover/focus via its own opacity transition below. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between p-2">
         {item.authorUrl ? (
           <a
             href={item.authorUrl}
@@ -127,7 +137,7 @@ export function MediaCard({
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`Open the original post for ${item.title}`}
-          className="pointer-events-auto grid size-7 place-items-center rounded-full bg-black/60 text-white backdrop-blur-xs transition-colors hover:bg-black/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
+          className="pointer-events-auto grid size-7 place-items-center rounded-full bg-black/60 text-white opacity-0 backdrop-blur-xs transition-opacity duration-150 hover:bg-black/80 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white group-hover:opacity-100"
         >
           <ArrowUpRight className="size-3.5" />
         </a>

--- a/components/design/section-header.tsx
+++ b/components/design/section-header.tsx
@@ -3,13 +3,24 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { DesignSection } from "@/content/design-taxonomy";
 import { designCategoryPath } from "@/content/design-taxonomy";
+import type { DesignSort } from "@/lib/design/types";
+import { relativeTime } from "@/lib/design/format";
+import { SortSelect } from "./sort-select";
 
+/**
+ * Header row + filter rail, recent.design mechanics: the title row sits above
+ * a dashed hairline, and the pills row is sticky under the 3.5rem site header
+ * so filters stay reachable while scrolling the feed. Every pill is a real
+ * navigable route (the SEO engine); prefetch keeps it feeling client-side.
+ */
 export function SectionHeader({
   section,
   activeCategory,
   count,
   heading,
   subheading,
+  updatedAt,
+  sort = "recent",
 }: {
   section: DesignSection;
   /** Undefined on the section index ("All" is active). */
@@ -18,70 +29,79 @@ export function SectionHeader({
   /** Category pages override the H1 — each indexable route needs its own. */
   heading?: string;
   subheading?: string;
+  /** Most recent published_at in the current view — "Last updated Xh ago". */
+  updatedAt?: string | null;
+  sort?: DesignSort;
 }) {
+  const updated = relativeTime(updatedAt ?? null);
+
+  // Fragment, not a wrapping <header>: the filter rail is position:sticky, and
+  // a sticky element can only stick within its PARENT's box. Wrapped in a
+  // <header> that ends just below it, it would scroll away with the page —
+  // as a direct child of <main> its sticky range is the whole column.
   return (
-    <header className="mb-6">
-      <div className="flex items-end justify-between gap-4">
-        <div className="min-w-0">
-          <h1 className="text-[15px] font-medium tracking-tight">
+    <>
+      {/* Title row */}
+      <header className="border-grid flex items-baseline justify-between gap-4 border-b px-4 py-4 sm:px-6">
+        <div className="flex min-w-0 items-baseline gap-3">
+          <h1 className="shrink-0 text-[15px] font-medium tracking-tight">
             {heading ?? section.name}
           </h1>
-          <p className="mt-1 text-[13px] text-muted-foreground">
+          <p className="hidden truncate text-[13px] text-muted-foreground sm:block">
             {subheading ?? section.description}
           </p>
         </div>
-        {typeof count === "number" && count > 0 && (
-          <p className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-            {count} {count === 1 ? "item" : "items"}
-          </p>
-        )}
-      </div>
+        <p className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+          {updated
+            ? `Last updated ${updated}`
+            : typeof count === "number" && count > 0
+              ? `${count} ${count === 1 ? "item" : "items"}`
+              : null}
+        </p>
+      </header>
 
-      {/* Category pills. Every one is a real navigable route — that is the SEO
-          engine — but prefetch keeps it feeling like a client-side filter. */}
-      <div className="relative mt-5">
-        <ul className="no-scrollbar flex gap-1.5 overflow-x-auto pb-1">
-          <li>
-            <Link
-              href={section.path}
-              scroll={false}
-              className={cn(
-                "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
-                !activeCategory
-                  ? "bg-foreground text-background"
-                  : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
-              )}
-            >
-              All
-            </Link>
-          </li>
-          {section.categories.map((category) => {
-            const active = activeCategory === category.slug;
-            return (
-              <li key={category.slug}>
-                <Link
-                  href={designCategoryPath(section, category.slug)}
-                  scroll={false}
-                  prefetch
-                  className={cn(
-                    "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
-                    active
-                      ? "bg-foreground text-background"
-                      : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
-                  )}
-                >
-                  {category.name}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-        {/* Edge fade so the scroll affordance reads without a scrollbar. */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-background to-transparent"
-        />
+      {/* Filter rail — sticky under the site header, above the feed. */}
+      <div className="border-grid sticky top-14 z-30 border-b bg-background/95 px-4 backdrop-blur-xs sm:px-6">
+        <div className="flex items-center gap-4 py-2.5">
+          <ul className="no-scrollbar relative flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
+            <li>
+              <Link
+                href={section.path}
+                scroll={false}
+                className={cn(
+                  "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
+                  !activeCategory
+                    ? "bg-foreground text-background"
+                    : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
+                )}
+              >
+                All
+              </Link>
+            </li>
+            {section.categories.map((category) => {
+              const active = activeCategory === category.slug;
+              return (
+                <li key={category.slug}>
+                  <Link
+                    href={designCategoryPath(section, category.slug)}
+                    scroll={false}
+                    prefetch
+                    className={cn(
+                      "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
+                      active
+                        ? "bg-foreground text-background"
+                        : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
+                    )}
+                  >
+                    {category.name}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <SortSelect value={sort} />
+        </div>
       </div>
-    </header>
+    </>
   );
 }

--- a/components/design/section-header.tsx
+++ b/components/design/section-header.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+import type { DesignSection } from "@/content/design-taxonomy";
+import { designCategoryPath } from "@/content/design-taxonomy";
+
+export function SectionHeader({
+  section,
+  activeCategory,
+  count,
+  heading,
+  subheading,
+}: {
+  section: DesignSection;
+  /** Undefined on the section index ("All" is active). */
+  activeCategory?: string;
+  count?: number;
+  /** Category pages override the H1 — each indexable route needs its own. */
+  heading?: string;
+  subheading?: string;
+}) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-end justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-[15px] font-medium tracking-tight">
+            {heading ?? section.name}
+          </h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            {subheading ?? section.description}
+          </p>
+        </div>
+        {typeof count === "number" && count > 0 && (
+          <p className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+            {count} {count === 1 ? "item" : "items"}
+          </p>
+        )}
+      </div>
+
+      {/* Category pills. Every one is a real navigable route — that is the SEO
+          engine — but prefetch keeps it feeling like a client-side filter. */}
+      <div className="relative mt-5">
+        <ul className="no-scrollbar flex gap-1.5 overflow-x-auto pb-1">
+          <li>
+            <Link
+              href={section.path}
+              scroll={false}
+              className={cn(
+                "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
+                !activeCategory
+                  ? "bg-foreground text-background"
+                  : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
+              )}
+            >
+              All
+            </Link>
+          </li>
+          {section.categories.map((category) => {
+            const active = activeCategory === category.slug;
+            return (
+              <li key={category.slug}>
+                <Link
+                  href={designCategoryPath(section, category.slug)}
+                  scroll={false}
+                  prefetch
+                  className={cn(
+                    "inline-block whitespace-nowrap rounded-full px-3 py-1 text-[12px] transition-colors",
+                    active
+                      ? "bg-foreground text-background"
+                      : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground",
+                  )}
+                >
+                  {category.name}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+        {/* Edge fade so the scroll affordance reads without a scrollbar. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-background to-transparent"
+        />
+      </div>
+    </header>
+  );
+}

--- a/components/design/sort-select.tsx
+++ b/components/design/sort-select.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { ChevronDown } from "lucide-react";
+
+import type { DesignSort } from "@/lib/design/types";
+import { cn } from "@/lib/utils";
+
+const OPTIONS: { value: DesignSort; label: string }[] = [
+  { value: "recent", label: "Recent" },
+  { value: "staff", label: "Staff picks" },
+  { value: "popular", label: "Popular" },
+];
+
+/**
+ * Sort persists in a cookie, never in the URL (spec §9): sorted views must not
+ * mint duplicate URLs for crawlers, and the choice should survive navigation.
+ * The server reads the cookie; this component only writes it and refreshes.
+ */
+export function SortSelect({ value }: { value: DesignSort }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <label
+      className={cn(
+        "relative flex shrink-0 cursor-pointer items-center gap-1 text-[12px] text-muted-foreground transition-opacity hover:text-foreground",
+        pending && "opacity-50",
+      )}
+    >
+      <span className="sr-only">Sort by</span>
+      <select
+        value={value}
+        onChange={(e) => {
+          document.cookie = `design_sort=${e.target.value}; path=/design; max-age=31536000; samesite=lax`;
+          startTransition(() => router.refresh());
+        }}
+        className="absolute inset-0 cursor-pointer appearance-none opacity-0"
+        aria-label="Sort items"
+      >
+        {OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <span aria-hidden>{OPTIONS.find((o) => o.value === value)?.label}</span>
+      <ChevronDown aria-hidden className="size-3" />
+    </label>
+  );
+}

--- a/components/seo/adsense-script.tsx
+++ b/components/seo/adsense-script.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname } from "next/navigation";
+
+const ADSENSE_CLIENT = "ca-pub-8119622964025792";
+
+/**
+ * AdSense is deliberately kept off the /design gallery routes.
+ *
+ * The gallery sells sponsorship inventory directly (sidebar, feed cards,
+ * right-rail units). Running AdSense on the same surface would cannibalise that
+ * inventory and cheapen the page for a fraction of the revenue. Everywhere else
+ * — docs, blog, marketing — is unchanged.
+ */
+export function AdSenseScript() {
+  const pathname = usePathname();
+  if (pathname?.startsWith("/design")) return null;
+
+  return (
+    <Script
+      id="adsense"
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
+      strategy="lazyOnload"
+      crossOrigin="anonymous"
+    />
+  );
+}

--- a/content/design-taxonomy.ts
+++ b/content/design-taxonomy.ts
@@ -1,0 +1,210 @@
+/**
+ * Spectrum Design — sections and category taxonomy.
+ *
+ * This is the single source of truth for /design routing and its SEO copy.
+ * It lives in code rather than the database on purpose: category pages are the
+ * primary organic-traffic engine, so every one of them must be statically
+ * generatable and must render its intro copy even when the gallery is empty or
+ * Supabase is unreachable. Items reference these slugs as text[].
+ *
+ * Intro copy is 150-250 words per the content plan and must stay unique per
+ * page — it is the indexable body of a category route.
+ */
+
+export type DesignSectionSlug =
+  | "feed"
+  | "websites"
+  | "og-images"
+  | "app-screenshots"
+  | "app-icons"
+  | "showcase";
+
+export type DesignLayout = "masonry" | "uniform" | "icons";
+
+export interface DesignCategory {
+  slug: string;
+  name: string;
+  /** Indexable intro copy for /design/<section>/c/<slug>. */
+  intro: string;
+}
+
+export interface DesignSection {
+  slug: DesignSectionSlug;
+  /** Route path. The main feed lives at /design, the rest are nested. */
+  path: string;
+  name: string;
+  /** One-line description shown in the page header and used as meta description. */
+  description: string;
+  layout: DesignLayout;
+  /** Fixed aspect ratio for uniform grids; null lets masonry use intrinsic size. */
+  aspectRatio: number | null;
+  categories: DesignCategory[];
+}
+
+const cat = (slug: string, name: string, intro: string): DesignCategory => ({
+  slug,
+  name,
+  intro,
+});
+
+export const DESIGN_SECTIONS: DesignSection[] = [
+  {
+    slug: "feed",
+    path: "/design",
+    name: "Design Inspiration",
+    description:
+      "A curated feed of interface, product and motion design worth studying.",
+    layout: "masonry",
+    aspectRatio: null,
+    categories: [
+      cat(
+        "web",
+        "Web",
+        "Web design inspiration collected from products and studios shipping real work. Each entry links back to the original source so you can study the live implementation rather than a static export. Look for how layout systems hold up across breakpoints, where designers spend their type budget, and which interactions survive contact with production. The strongest web work tends to be quiet: a considered grid, restrained colour, and one or two moments of motion placed where they carry meaning. Use this as a reference library when you are stuck on structure, not just surface.",
+      ),
+      cat(
+        "interface",
+        "Interface",
+        "Interface design inspiration focused on the dense, working parts of software: tables, forms, settings, empty states and navigation. These are the screens users actually live in, and they reward craft that never shows up in a hero shot. Pay attention to how spacing establishes hierarchy without borders, how disabled and loading states are handled, and where designers chose a boring pattern because it was the correct one. Every item links to its source and is tagged with the Spectrum UI components that could rebuild it.",
+      ),
+      cat(
+        "branding",
+        "Branding",
+        "Brand and identity design inspiration: wordmarks, logo systems, colour palettes and the typographic rules that hold them together. Strong identity work reads at every size and survives being reproduced badly, so look at how these marks behave when they are small, monochrome or moving. The best systems here define a small number of decisions precisely rather than a large number loosely. Useful when you are establishing a visual language for a product and need to see how others resolved the same constraints.",
+      ),
+      cat(
+        "product",
+        "Product",
+        "Product design inspiration showing complete flows rather than isolated screens: onboarding, checkout, upgrade paths and the transitions between them. Individual screens are easy; sequences are where design gets hard, because state has to persist and the user has to stay oriented. Study where these flows reduce steps, where they deliberately add friction, and how they communicate progress. Each item is attributed to its original creator and links back to the source post.",
+      ),
+      cat(
+        "typography",
+        "Typography",
+        "Typography inspiration for interfaces and editorial layouts: type scales, pairings, optical sizing and the spacing decisions that make text comfortable to read. Most interface typography fails in the same few ways — line length too long, leading too tight, too many weights — so it is worth studying work that gets the fundamentals right before reaching for anything expressive. Look at how these examples handle numerals, long strings and small sizes, which is where type systems usually break.",
+      ),
+      cat(
+        "motion",
+        "Motion",
+        "Motion design inspiration for interfaces: transitions, micro-interactions, loading states and gesture-driven animation. Good motion is usually invisible — it explains where something came from and where it went, and it gets out of the way. Watch the timing and easing rather than the effect: most of the quality in these examples comes from durations under 300ms and curves that decelerate. Note also which of them respect reduced-motion, because that is the difference between polish and an accessibility problem.",
+      ),
+      cat(
+        "illustration",
+        "Illustration",
+        "Illustration inspiration for product surfaces: empty states, onboarding, error pages and marketing sites. Product illustration has a harder job than editorial illustration because it has to carry a house style across dozens of scenes and still render legibly at small sizes. Study how these systems constrain palette and line weight so that new scenes can be drawn later without redesigning the whole set.",
+      ),
+      cat(
+        "3d",
+        "3D",
+        "3D design inspiration for interfaces and marketing: rendered product shots, spatial scenes and real-time WebGL work. Look at how lighting and material choices carry hierarchy, and at where the 3D is doing real communicative work rather than decoration. For anything real-time, the interesting constraint is budget — how much fidelity survives once it has to run at 60fps on a mid-range laptop.",
+      ),
+      cat(
+        "editorial",
+        "Editorial",
+        "Editorial design inspiration: long-form layouts, article typography, pull quotes and the pacing of text and image. Editorial work is a useful corrective to interface design because it optimises for sustained reading rather than task completion. Study measure, leading and the vertical rhythm between elements, then note how little decoration the best examples need.",
+      ),
+    ],
+  },
+  {
+    slug: "websites",
+    path: "/design/websites",
+    name: "Websites",
+    description: "Full-page screenshots of websites worth studying.",
+    layout: "uniform",
+    aspectRatio: 16 / 10,
+    categories: [
+      cat("ai", "AI", "Website design inspiration from AI products and research labs. This category moves fast and the conventions are still forming, which makes it a useful place to watch positioning problems get solved in public: how to explain a model, how to demo something non-deterministic, and how to build trust around output quality. Note how many of these sites lead with an interactive demo rather than a description."),
+      cat("saas", "SaaS", "SaaS website design inspiration: landing pages, pricing, feature tours and docs entry points. The job is consistently the same — explain a product quickly to someone who arrived from a link — so the differences in approach are instructive. Look at how pricing pages handle tier comparison, and how feature sections avoid becoming an undifferentiated wall of cards."),
+      cat("agency", "Agency", "Agency and studio website inspiration, where the site is itself the portfolio piece. These tend to push further on motion and layout than product sites can afford to, so they are a good place to find techniques worth borrowing selectively. Watch for how case studies are structured, which is usually the hardest content problem an agency site has."),
+      cat("portfolio", "Portfolio", "Personal portfolio design inspiration from designers and engineers. The constraint here is that the work has to speak while the site stays out of the way, and the best examples resolve that with restraint rather than novelty. Useful for seeing how people sequence projects and write about their own contribution."),
+      cat("ecommerce", "Ecommerce", "Ecommerce website inspiration: product pages, collection grids, cart and checkout. Conversion pressure makes this category unusually rigorous — most decisions here have been tested. Study how imagery is cropped and sequenced, how variant selection is handled, and how much information is deferred rather than shown."),
+      cat("startup", "Startup", "Early-stage startup website inspiration. These sites are usually built fast under real constraints, which makes them a realistic reference for small teams. Look at how they establish credibility without a customer logo wall, and how they handle a product that is still changing weekly."),
+      cat("finance", "Finance", "Fintech and finance website inspiration, where trust and clarity dominate every other consideration. Numbers, security signals and regulatory copy all have to be legible without making the page feel like a disclosure document. Watch how these sites use restraint and tabular figures to feel precise."),
+    ],
+  },
+  {
+    slug: "og-images",
+    path: "/design/og-images",
+    name: "OG Images",
+    description: "Open Graph cards that actually earn the click.",
+    layout: "uniform",
+    aspectRatio: 1.91,
+    categories: [
+      cat("saas", "SaaS", "Open Graph card inspiration from SaaS products. An OG image gets read at thumbnail size in a crowded feed, so the entire design problem is legibility under compression. The examples that work commit to one message and set it large; the ones that fail try to reproduce the landing page. Note how many use a consistent template so that every shared URL reinforces the same identity."),
+      cat("editorial", "Editorial", "Editorial and blog OG card inspiration. These have to carry a headline of unpredictable length, which makes them a type-setting problem more than a layout one. Study how the strongest examples handle long titles without shrinking text into illegibility, and how author and publication are given just enough presence."),
+      cat("developer-tools", "Developer Tools", "OG cards from developer tools and open source projects. This category leans on monospace, terminal motifs and code fragments, which read well at small sizes because of their strong horizontal rhythm. Useful reference if you are generating cards dynamically and need a template that survives arbitrary repo names."),
+    ],
+  },
+  {
+    slug: "app-screenshots",
+    path: "/design/app-screenshots",
+    name: "App Screenshots",
+    description: "App Store screenshot sets and the stories they tell.",
+    layout: "uniform",
+    aspectRatio: 9 / 19.5,
+    categories: [
+      cat("productivity", "Productivity", "App Store screenshot inspiration from productivity apps. A screenshot set is a five-panel pitch seen mostly by people swiping fast, so sequencing matters more than any individual frame. Study which apps lead with the outcome rather than the interface, and how captions carry the argument when the UI alone cannot."),
+      cat("health", "Health", "Health and fitness app screenshot inspiration. These sets have to communicate progress and habit over time, which is hard to show in static frames. Look at how data visualisation is simplified for the store listing, and how tone is set through colour and photography."),
+      cat("finance", "Finance", "Finance app screenshot inspiration. Trust is the whole job here, and it is usually established through precision: aligned figures, restrained colour, and screens that look like they were photographed rather than illustrated. Note how sensitive data is plausibly faked without looking fake."),
+    ],
+  },
+  {
+    slug: "app-icons",
+    path: "/design/app-icons",
+    name: "App Icons",
+    description: "iOS and macOS icons, studied at the size they are actually seen.",
+    layout: "icons",
+    aspectRatio: 1,
+    categories: [
+      cat("productivity", "Productivity", "Productivity app icon inspiration. An icon is read at roughly 60 pixels on a crowded home screen, so it has to resolve to a single recognisable shape and one dominant colour. The best examples here would still be identifiable as a silhouette. Study how few elements the strongest icons contain."),
+      cat("social", "Social", "Social app icon inspiration. This category competes hardest for recognition, which pushes designs toward bold single glyphs and saturated brand colour. Useful for seeing how a mark stays distinct when every competitor is reaching for the same visual strategy."),
+      cat("developer", "Developer", "Developer tool icon inspiration. These skew toward abstract marks, terminal references and monochrome palettes, and they often need to work on both light and dark system backgrounds. Note how depth is used sparingly to keep them legible at small sizes."),
+    ],
+  },
+  {
+    slug: "showcase",
+    path: "/design/showcase",
+    name: "Built with Spectrum",
+    description: "Real products shipped with Spectrum UI components.",
+    layout: "masonry",
+    aspectRatio: null,
+    categories: [
+      cat("saas", "SaaS", "SaaS products built with Spectrum UI. Each case study lists the components used and links straight to their documentation with copy-paste install commands, so you can go from a screenshot you like to the source in one step. This is the part of the gallery no other inspiration site can reproduce: the work and the building blocks are in the same place."),
+      cat("ai", "AI", "AI products built with Spectrum UI, many of them using the AI Assistants block set. Useful for seeing how the streaming, reasoning-trace and tool-call surfaces behave inside a real product rather than a demo. Every entry links to the components that back it."),
+      cat("portfolio", "Portfolio", "Personal sites and portfolios built with Spectrum UI. These tend to use the animated and motion components most heavily, which makes them a good reference for how much motion is too much. Each links to the components used."),
+    ],
+  },
+];
+
+export const DESIGN_SECTION_MAP = new Map(
+  DESIGN_SECTIONS.map((s) => [s.slug, s]),
+);
+
+export function findDesignSection(slug: string): DesignSection | undefined {
+  return DESIGN_SECTION_MAP.get(slug as DesignSectionSlug);
+}
+
+export function findDesignCategory(
+  section: DesignSectionSlug,
+  categorySlug: string,
+): DesignCategory | undefined {
+  return DESIGN_SECTION_MAP.get(section)?.categories.find(
+    (c) => c.slug === categorySlug,
+  );
+}
+
+/** Route for a category page. Real routes, never query strings — this is the SEO engine. */
+export function designCategoryPath(
+  section: DesignSection,
+  categorySlug: string,
+): string {
+  return section.slug === "feed"
+    ? `/design/c/${categorySlug}`
+    : `${section.path}/c/${categorySlug}`;
+}
+
+/** Facet vocabulary. Cross-cuts every section; used for filtering, not routing. */
+export const DESIGN_FACETS = {
+  style: ["minimal", "playful", "brutalist", "abstract", "editorial", "retro"],
+  color: ["dark", "light", "gradient", "monochrome", "vivid", "pastel"],
+  interaction: ["transitions", "scroll", "hover", "drag", "3d", "parallax"],
+} as const;

--- a/design-schema.sql
+++ b/design-schema.sql
@@ -1,0 +1,136 @@
+-- Spectrum Design — gallery schema
+-- Run this in Supabase before enabling the /design section.
+--
+-- Design notes (deliberate departures from the original Prisma sketch):
+--
+--  * Categories and facets are NOT tables. The taxonomy lives in code at
+--    content/design-taxonomy.ts so that category routes are statically
+--    generatable and every /design/c/<slug> page renders (with its SEO intro
+--    copy) before a single row exists. Items reference them as text[] slugs,
+--    which Postgres indexes well with GIN and which removes four join tables.
+--
+--  * Enums are CHECK constraints rather than Postgres ENUM types. Adding a
+--    value to a real ENUM requires ALTER TYPE and cannot run inside a
+--    transaction on older Postgres; a CHECK is edited with one statement.
+--
+--  * Media lives in its own table because a single item can be an ordered
+--    slide set (app store screenshots, carousels).
+
+CREATE TABLE IF NOT EXISTS design_items (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug            TEXT NOT NULL UNIQUE,
+  short_id        TEXT NOT NULL UNIQUE,            -- 7-char nanoid, prefixes the slug
+  section         TEXT NOT NULL CHECK (section IN (
+                    'feed','websites','og-images','app-screenshots','app-icons','showcase'
+                  )),
+  title           TEXT NOT NULL,
+  description     TEXT NOT NULL,                   -- 1-3 original sentences, indexable
+  status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN ('draft','published','hidden')),
+  staff_pick      BOOLEAN NOT NULL DEFAULT FALSE,
+  published_at    TIMESTAMPTZ,
+
+  -- Attribution. Never publish without it.
+  author_name     TEXT NOT NULL,
+  author_handle   TEXT,
+  author_avatar   TEXT,
+  author_url      TEXT,
+  source_url      TEXT NOT NULL,
+  source_platform TEXT NOT NULL DEFAULT 'web'
+                    CHECK (source_platform IN ('x','instagram','dribbble','web','other')),
+
+  -- Taxonomy: slugs validated against content/design-taxonomy.ts, not the DB.
+  categories      TEXT[] NOT NULL DEFAULT '{}',
+  facet_style     TEXT[] NOT NULL DEFAULT '{}',
+  facet_color     TEXT[] NOT NULL DEFAULT '{}',
+  facet_interaction TEXT[] NOT NULL DEFAULT '{}',
+
+  -- The wedge: which Spectrum UI components could rebuild this.
+  related_components TEXT[] NOT NULL DEFAULT '{}',
+
+  impressions     INTEGER NOT NULL DEFAULT 0,
+  outbound_clicks INTEGER NOT NULL DEFAULT 0,
+  score           DOUBLE PRECISION NOT NULL DEFAULT 0,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Feed reads are always (section, status) filtered then ordered. These two
+-- cover "Recent" and "Popular"; the partial predicate keeps drafts out of the
+-- index entirely so it stays small as the draft queue grows.
+CREATE INDEX IF NOT EXISTS idx_design_items_recent
+  ON design_items (section, published_at DESC)
+  WHERE status = 'published';
+
+CREATE INDEX IF NOT EXISTS idx_design_items_score
+  ON design_items (section, score DESC)
+  WHERE status = 'published';
+
+CREATE INDEX IF NOT EXISTS idx_design_items_categories
+  ON design_items USING GIN (categories);
+
+CREATE INDEX IF NOT EXISTS idx_design_items_slug ON design_items (slug);
+
+CREATE TABLE IF NOT EXISTS design_media (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id        UUID NOT NULL REFERENCES design_items(id) ON DELETE CASCADE,
+  position       INTEGER NOT NULL DEFAULT 0,
+  kind           TEXT NOT NULL DEFAULT 'image' CHECK (kind IN ('image','video')),
+
+  -- width/height are REQUIRED: the feed reserves space from the stored aspect
+  -- ratio, which is what makes CLS ~0. Never insert media without them.
+  width          INTEGER NOT NULL,
+  height         INTEGER NOT NULL,
+  blurhash       TEXT,
+  dominant_color TEXT,
+
+  -- R2 public URLs. src_set maps width -> url, e.g. {"480":"...","1080":"..."}
+  src_set        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  video_url      TEXT,
+  video_webm     TEXT,
+  poster_url     TEXT,
+  duration_ms    INTEGER,
+
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (item_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_media_item ON design_media (item_id, position);
+
+-- Tracked outbound redirects for /go/[code].
+CREATE TABLE IF NOT EXISTS design_outbound_links (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code       TEXT NOT NULL UNIQUE,
+  target     TEXT NOT NULL,
+  kind       TEXT NOT NULL CHECK (kind IN ('sponsor','tool','job','source','item')),
+  ref_id     UUID,
+  clicks     INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_outbound_code ON design_outbound_links (code);
+
+-- Admin gating. NextAuth owns sessions; this column is read in the jwt callback
+-- and surfaced on the session, the same way github_username already is.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'user'
+  CHECK (role IN ('user','admin'));
+
+-- Row Level Security: the app reads through the service-role key server-side,
+-- so RLS is a backstop against the anon key ever being pointed at these tables.
+ALTER TABLE design_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE design_media ENABLE ROW LEVEL SECURITY;
+ALTER TABLE design_outbound_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS design_items_public_read ON design_items;
+CREATE POLICY design_items_public_read ON design_items
+  FOR SELECT USING (status = 'published');
+
+DROP POLICY IF EXISTS design_media_public_read ON design_media;
+CREATE POLICY design_media_public_read ON design_media
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM design_items i
+      WHERE i.id = design_media.item_id AND i.status = 'published'
+    )
+  );

--- a/lib/design/format.ts
+++ b/lib/design/format.ts
@@ -1,0 +1,17 @@
+/** Coarse relative time for the "Last updated Xm ago" header slot.
+ *  Coarse on purpose: minute-level precision would make cached HTML read as
+ *  stale the moment it is served. */
+export function relativeTime(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+
+  const mins = Math.max(1, Math.round((Date.now() - then) / 60_000));
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  return `${months}mo ago`;
+}

--- a/lib/design/queries.ts
+++ b/lib/design/queries.ts
@@ -1,0 +1,269 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import type { DesignSectionSlug } from "@/content/design-taxonomy";
+import type {
+  DesignItem,
+  DesignMedia,
+  FeedQuery,
+  FeedResult,
+} from "./types";
+
+export const DESIGN_PAGE_SIZE = 60;
+
+/**
+ * "The gallery isn't provisioned yet" rather than "something is broken", so
+ * /design renders a setup state instead of a 500 before design-schema.sql has
+ * been applied.
+ *
+ * Two families of code matter here: raw Postgres (42P01 undefined_table, 42703
+ * undefined_column) and PostgREST's own schema-cache miss (PGRST205), which is
+ * what Supabase actually returns for a missing table — it never surfaces 42P01.
+ */
+const NOT_PROVISIONED = new Set(["42P01", "42703", "PGRST205", "PGRST204"]);
+
+function isNotProvisioned(error: { code?: string; message?: string }): boolean {
+  if (error.code && NOT_PROVISIONED.has(error.code)) return true;
+  return /could not find the table|schema cache|does not exist/i.test(
+    error.message ?? "",
+  );
+}
+
+const ITEM_COLUMNS = `
+  id, slug, short_id, section, title, description, status, staff_pick, published_at,
+  author_name, author_handle, author_avatar, author_url, source_url, source_platform,
+  categories, facet_style, facet_color, facet_interaction, related_components,
+  impressions, outbound_clicks, score
+`;
+
+function mapMedia(row: any): DesignMedia {
+  return {
+    id: row.id,
+    itemId: row.item_id,
+    position: row.position ?? 0,
+    kind: row.kind ?? "image",
+    width: row.width,
+    height: row.height,
+    blurhash: row.blurhash ?? null,
+    dominantColor: row.dominant_color ?? null,
+    srcSet: (row.src_set ?? {}) as Record<string, string>,
+    videoUrl: row.video_url ?? null,
+    videoWebm: row.video_webm ?? null,
+    posterUrl: row.poster_url ?? null,
+    durationMs: row.duration_ms ?? null,
+  };
+}
+
+function mapItem(row: any, media: DesignMedia[]): DesignItem {
+  return {
+    id: row.id,
+    slug: row.slug,
+    shortId: row.short_id,
+    section: row.section as DesignSectionSlug,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    staffPick: !!row.staff_pick,
+    publishedAt: row.published_at ?? null,
+    authorName: row.author_name,
+    authorHandle: row.author_handle ?? null,
+    authorAvatar: row.author_avatar ?? null,
+    authorUrl: row.author_url ?? null,
+    sourceUrl: row.source_url,
+    sourcePlatform: row.source_platform ?? "web",
+    categories: row.categories ?? [],
+    facetStyle: row.facet_style ?? [],
+    facetColor: row.facet_color ?? [],
+    facetInteraction: row.facet_interaction ?? [],
+    relatedComponents: row.related_components ?? [],
+    impressions: row.impressions ?? 0,
+    outboundClicks: row.outbound_clicks ?? 0,
+    score: row.score ?? 0,
+    media,
+  };
+}
+
+/** Attach ordered media to a set of items in one round trip (no N+1). */
+async function attachMedia(rows: any[]): Promise<DesignItem[]> {
+  if (rows.length === 0) return [];
+
+  const ids = rows.map((r) => r.id);
+  const { data: mediaRows, error } = await supabaseAdmin
+    .from("design_media")
+    .select("*")
+    .in("item_id", ids)
+    .order("position", { ascending: true });
+
+  if (error && !isNotProvisioned(error)) {
+    console.error("[design] media fetch failed:", error.message);
+  }
+
+  const byItem = new Map<string, DesignMedia[]>();
+  for (const m of mediaRows ?? []) {
+    const mapped = mapMedia(m);
+    const list = byItem.get(mapped.itemId);
+    if (list) list.push(mapped);
+    else byItem.set(mapped.itemId, [mapped]);
+  }
+
+  return rows.map((r) => mapItem(r, byItem.get(r.id) ?? []));
+}
+
+/**
+ * Cursor-paginated feed.
+ *
+ * Note on the cursor: Supabase/PostgREST has no keyset-pagination helper, so
+ * this uses `.range()` with an offset encoded in the cursor. That is correct
+ * and cheap at the page depths a gallery actually reaches; if the feed ever
+ * gets deep enough for offset scanning to hurt, switch to a keyset predicate
+ * on (published_at, id).
+ */
+const getFeedUncached = async (
+  section: DesignSectionSlug,
+  category: string | undefined,
+  sort: NonNullable<FeedQuery["sort"]>,
+  cursor: string | undefined,
+  limit: number,
+): Promise<FeedResult> => {
+  const offset = cursor ? Number.parseInt(cursor, 10) || 0 : 0;
+
+  try {
+    let q = supabaseAdmin
+      .from("design_items")
+      .select(ITEM_COLUMNS)
+      .eq("section", section)
+      .eq("status", "published");
+
+    if (category) {
+      // GIN-indexed array containment.
+      q = q.contains("categories", [category]);
+    }
+
+    if (sort === "popular") {
+      q = q.order("score", { ascending: false });
+    } else if (sort === "staff") {
+      q = q
+        .order("staff_pick", { ascending: false })
+        .order("published_at", { ascending: false, nullsFirst: false });
+    } else {
+      q = q.order("published_at", { ascending: false, nullsFirst: false });
+    }
+
+    // Fetch one extra row to know whether another page exists.
+    const { data, error } = await q.range(offset, offset + limit);
+
+    if (error) {
+      if (isNotProvisioned(error)) {
+        // Expected before design-schema.sql is applied — not an error.
+        return { items: [], nextCursor: null, unavailable: true };
+      }
+      console.error("[design] feed query failed:", error.message);
+      return { items: [], nextCursor: null, unavailable: false };
+    }
+
+    const rows = data ?? [];
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const items = await attachMedia(page);
+
+    return {
+      items,
+      nextCursor: hasMore ? String(offset + limit) : null,
+      unavailable: false,
+    };
+  } catch (err) {
+    console.error("[design] feed query threw:", err);
+    return { items: [], nextCursor: null, unavailable: true };
+  }
+};
+
+/**
+ * Cached feed reader. unstable_cache keys on the argument list, so each
+ * (section, category, sort, page) combination gets its own entry.
+ *
+ * This wrapper is what keeps the gallery routes statically renderable: an
+ * uncached Supabase call inside a page opts that route out of ISR entirely.
+ * Publishing an item should call revalidateTag("design-items").
+ */
+const getFeedCached = unstable_cache(getFeedUncached, ["design-feed"], {
+  revalidate: 300,
+  tags: ["design-items"],
+});
+
+export async function getFeed(query: FeedQuery): Promise<FeedResult> {
+  const {
+    section,
+    category,
+    sort = "recent",
+    cursor,
+    limit = DESIGN_PAGE_SIZE,
+  } = query;
+  return getFeedCached(section, category, sort, cursor, limit);
+}
+
+/** Single item by slug, for /design/i/[slug]. */
+export async function getItemBySlug(slug: string): Promise<DesignItem | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("design_items")
+      .select(ITEM_COLUMNS)
+      .eq("slug", slug)
+      .eq("status", "published")
+      .maybeSingle();
+
+    if (error || !data) return null;
+    const [item] = await attachMedia([data]);
+    return item ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Published slugs for sitemap + generateStaticParams. Never throws. */
+export async function getPublishedSlugs(): Promise<
+  { slug: string; publishedAt: string | null }[]
+> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("design_items")
+      .select("slug, published_at")
+      .eq("status", "published")
+      .order("published_at", { ascending: false });
+
+    if (error || !data) return [];
+    return data.map((r) => ({ slug: r.slug, publishedAt: r.published_at ?? null }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Section counts for the sidebar.
+ *
+ * Wrapped in unstable_cache because this runs in the /design layout, and an
+ * uncached async call there opts the entire subtree out of static rendering —
+ * every gallery route would become dynamic and lose ISR. Caching it keeps the
+ * feed and all category pages statically renderable, which the LCP budget needs.
+ */
+export const getSectionCounts = unstable_cache(
+  async (): Promise<Record<string, number>> => {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from("design_items")
+        .select("section")
+        .eq("status", "published");
+
+      if (error || !data) return {};
+      return data.reduce<Record<string, number>>((acc, r) => {
+        acc[r.section] = (acc[r.section] ?? 0) + 1;
+        return acc;
+      }, {});
+    } catch {
+      return {};
+    }
+  },
+  ["design-section-counts"],
+  { revalidate: 300, tags: ["design-items"] },
+);

--- a/lib/design/types.ts
+++ b/lib/design/types.ts
@@ -1,0 +1,75 @@
+import type { DesignSectionSlug } from "@/content/design-taxonomy";
+
+export type DesignStatus = "draft" | "published" | "hidden";
+export type DesignSourcePlatform = "x" | "instagram" | "dribbble" | "web" | "other";
+export type DesignMediaKind = "image" | "video";
+
+/** Map of rendered width -> public R2 URL, e.g. { "480": "https://…" }. */
+export type SrcSet = Record<string, string>;
+
+export interface DesignMedia {
+  id: string;
+  itemId: string;
+  position: number;
+  kind: DesignMediaKind;
+  /** Required. The feed reserves space from this ratio, which is what keeps CLS at ~0. */
+  width: number;
+  height: number;
+  blurhash: string | null;
+  dominantColor: string | null;
+  srcSet: SrcSet;
+  videoUrl: string | null;
+  videoWebm: string | null;
+  posterUrl: string | null;
+  durationMs: number | null;
+}
+
+export interface DesignItem {
+  id: string;
+  slug: string;
+  shortId: string;
+  section: DesignSectionSlug;
+  title: string;
+  description: string;
+  status: DesignStatus;
+  staffPick: boolean;
+  publishedAt: string | null;
+
+  authorName: string;
+  authorHandle: string | null;
+  authorAvatar: string | null;
+  authorUrl: string | null;
+  sourceUrl: string;
+  sourcePlatform: DesignSourcePlatform;
+
+  categories: string[];
+  facetStyle: string[];
+  facetColor: string[];
+  facetInteraction: string[];
+  relatedComponents: string[];
+
+  impressions: number;
+  outboundClicks: number;
+  score: number;
+
+  media: DesignMedia[];
+}
+
+export type DesignSort = "recent" | "staff" | "popular";
+
+export interface FeedQuery {
+  section: DesignSectionSlug;
+  category?: string;
+  sort?: DesignSort;
+  /** Cursor is the previous page's last item id. */
+  cursor?: string;
+  limit?: number;
+}
+
+export interface FeedResult {
+  items: DesignItem[];
+  nextCursor: string | null;
+  /** True when the gallery tables are not provisioned yet. Lets the UI show
+   *  a setup state instead of an error, so /design renders before any data. */
+  unavailable: boolean;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,7 +22,14 @@ const nextConfig = {
       "res.cloudinary.com",
       "genie.arihantcodes.com",
       "www.shadcnblocks.com",
-    ].map((hostname) => ({ protocol: 'https', hostname, pathname: '/**' })),
+      // Cloudflare R2 bucket serving /design gallery media. Set
+      // NEXT_PUBLIC_R2_PUBLIC_HOST to the bucket's public hostname (either the
+      // pub-<id>.r2.dev subdomain or a custom domain). next/image rejects any
+      // host that is not listed here, so gallery images 400 without it.
+      process.env.NEXT_PUBLIC_R2_PUBLIC_HOST,
+    ]
+      .filter(Boolean)
+      .map((hostname) => ({ protocol: 'https', hostname, pathname: '/**' })),
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,6 +27,10 @@ const nextConfig = {
       // pub-<id>.r2.dev subdomain or a custom domain). next/image rejects any
       // host that is not listed here, so gallery images 400 without it.
       process.env.NEXT_PUBLIC_R2_PUBLIC_HOST,
+      // Supabase Storage serves the seeded /design media (public bucket
+      // `design-media`) until the R2 ingest pipeline exists.
+      process.env.NEXT_PUBLIC_SUPABASE_URL &&
+        new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname,
     ]
       .filter(Boolean)
       .map((hostname) => ({ protocol: 'https', hostname, pathname: '/**' })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "react-use-measure": "^2.1.7",
         "recharts": "^2.15.3",
         "resend": "^4.0.1-alpha.0",
+        "server-only": "^0.0.1",
         "shiki": "^3.9.2",
         "sonner": "^2.0.7",
         "streamifier": "^0.1.1",
@@ -10371,6 +10372,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-use-measure": "^2.1.7",
     "recharts": "^2.15.3",
     "resend": "^4.0.1-alpha.0",
+    "server-only": "^0.0.1",
     "shiki": "^3.9.2",
     "sonner": "^2.0.7",
     "streamifier": "^0.1.1",


### PR DESCRIPTION
First two vertical slices of **Spectrum Design** (`/design`) — a curated design-inspiration gallery modelled on recent.design's mechanics and IA, expressed in this site's own visual language. Every route renders today; the gallery is already seeded with 16 live items.

## What's in this PR

### Data layer (Supabase)
- `design-schema.sql` (applied to Supabase already): `design_items`, `design_media`, `design_outbound_links`, a `role` column on `users` for future admin gating, partial indexes filtered to published rows, and RLS policies as a backstop.
- Two deliberate departures from the original spec's Prisma sketch:
  - **Taxonomy lives in code** (`content/design-taxonomy.ts`), not the DB — items reference categories as `text[]` slugs (GIN-indexed). This is what lets every category page be statically known and render its SEO copy before a single row exists, and it removes four join tables.
  - **CHECK constraints instead of Postgres ENUMs** — editable in one statement.
- Query layer (`lib/design/queries.ts`) wrapped in `unstable_cache` with a shared `design-items` tag; degrades to a "not provisioned" state instead of a 500 if the tables don't exist.

### Routes
| Route | Notes |
|---|---|
| `/design` | Masonry feed, `ItemList` JSON-LD, "Last updated Xm ago" |
| `/design/c/[category]` ×9 | **Real navigable routes, not query strings** — each with its own H1, title, meta description, `BreadcrumbList`+`ItemList` JSON-LD, and 150–250 words of unique indexable intro copy. This is the organic-traffic engine. |
| `/go/[code]` | Tracked outbound redirects (302, http(s)-only destinations, fire-and-forget click counts, `noindex` + `nofollow` on paid links) |

### Shell — recent.design mechanics, Spectrum's language
- Bordered three-column layout using the site's existing `container-wrapper` dashed-hairline convention; rails divide from the feed with the same dashed border.
- Left rail: section nav with item counts and active dot. Right rail: house unit (job listings land here later).
- **Sticky filter rail** under the 3.5rem site header (rendered as a sibling of the title row, not inside it — `position:sticky` can only stick within its parent's box).
- **Sort** (Recent / Staff picks / Popular) persists in a cookie, never in the URL — no duplicate-content risk from sorted views.
- CSS multi-column masonry (no JS masonry): no measurement pass, correct from SSR. Cards reserve their box from stored media aspect ratios → ~0 CLS.
- **Video cards** per spec §7: muted loop, plays at ≥50% visibility, pauses off-screen / hidden tab / `prefers-reduced-motion`. This is also the GIF path (GIFs transcode to mp4 at ingest).
- AdSense is now **suppressed on `/design` only** (`components/seo/adsense-script.tsx`) so it can't cannibalise directly-sold sponsorship inventory; unchanged everywhere else.

### Seed content (16 items, live now)
15 real product screens curated via the Mobbin MCP (web dashboards, iOS onboarding, landing heroes) with original editorial descriptions and source attribution, plus a self-rendered 6s gradient-motion mp4 exercising the video path. Media is **rehosted in the public Supabase Storage bucket `design-media`** — Mobbin's CDN URLs are signed and expire, so hotlinking would have left blank cards within days. Migration to R2 later needs no schema change (`NEXT_PUBLIC_R2_PUBLIC_HOST` is already wired into `remotePatterns`).

## Verification
- Build ✅ · 9/9 test suites ✅ · `tsc --noEmit` 0 errors ✅ · ESLint clean on new files ✅
- Browser-verified against the production build: 16 cards render, video plays and pauses correctly, all five seeded category filters return the right subsets, sort reorders and persists, sticky rail pins at 56px, dark mode clean, zero console errors.
- AdSense verified absent on `/design`, still loading on `/docs/*`.
- Metadata-uniqueness test confirms no title/description collisions with the existing 107 public pages.

## Known / deferred
- The seeded Mobbin screens are copyrighted app screenshots — fine as seed content, but the §14 takedown flow should exist before heavy promotion.
- `/design` sitemap entries, the item detail page (`/design/i/[slug]`), and `/design/admin` (ingest UI) are the next slices.
- True ISR for the gallery is blocked by the root layout's `await auth()` (pre-existing, affects all 135 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the `/design` inspiration gallery with a code-driven taxonomy, Supabase schema, bordered shell, masonry feed (with video), and tracked `/go` redirects. All routes render now; gallery is seeded with 16 items and AdSense is suppressed on `/design`.

- **New Features**
  - Supabase schema: `design_items`, `design_media`, `design_outbound_links`, `users.role`; categories as `text[]` slugs; CHECK constraints; partial indexes; RLS.
  - Taxonomy in `content/design-taxonomy.ts`; static category routes with unique intro copy and JSON‑LD; `/design` and nine `/design/c/[category]` pages.
  - UI shell: bordered three‑column layout, sticky filter rail, sidebar counts; sort (Recent/Staff/Popular) via cookie.
  - Feed: CSS multi‑column masonry; video cards that play only in view and respect reduced motion; ItemList/BreadcrumbList JSON‑LD; caching via `unstable_cache` with the `design-items` tag.
  - `/go/[code]` tracked redirects (302, http(s)-only, fire‑and‑forget click counts; `nofollow` on paid).
  - AdSense kept off `/design` via `AdSenseScript`; unchanged elsewhere.
  - Image hosts added to `next/image` remotePatterns using `NEXT_PUBLIC_R2_PUBLIC_HOST` and the Supabase host.

- **Migration**
  - Run `design-schema.sql` in Supabase to create gallery tables and policies.
  - Set `NEXT_PUBLIC_R2_PUBLIC_HOST` (or ensure `NEXT_PUBLIC_SUPABASE_URL` is set) so gallery media loads.
  - Call `revalidateTag('design-items')` on publish to refresh cached feeds.

<sup>Written for commit 55ade7cee1dd83906a369e606e3b1ebca7a24cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arihantcodes/spectrum-ui/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

